### PR TITLE
FIX: wp.blocks.query bug with wp.blocks.source 

### DIFF
--- a/03-editable-esnext/block.js
+++ b/03-editable-esnext/block.js
@@ -1,5 +1,5 @@
 const { __ } = wp.i18n;
-const { registerBlockType, Editable, query: { children } } = wp.blocks;
+const { registerBlockType, Editable, source: { children } } = wp.blocks;
 
 registerBlockType( 'gutenberg-examples/03-editable-esnext', {
 	title: __( 'Example: Editable (esnext)' ),

--- a/03-editable/block.js
+++ b/03-editable/block.js
@@ -8,7 +8,7 @@
 	var el = element.createElement;
 	var __ = i18n.__;
 	var Editable = blocks.Editable;
-	var children = blocks.query.children;
+	var children = blocks.source.children;
 
 	blocks.registerBlockType( 'gutenberg-examples/03-editable', {
 		title: __( 'Example: Editable', 'gutenberg-examples' ),

--- a/04-controls-esnext/block.js
+++ b/04-controls-esnext/block.js
@@ -2,7 +2,7 @@ const { __ } = wp.i18n;
 const {
 	registerBlockType,
 	Editable,
-	query: { children },
+	source: { children },
 	AlignmentToolbar,
 	BlockControls
 } = wp.blocks;

--- a/04-controls/block.js
+++ b/04-controls/block.js
@@ -7,7 +7,7 @@
 	var el = element.createElement;
 	var __ = i18n.__;
 	var Editable = blocks.Editable;
-	var children = blocks.query.children;
+	var children = blocks.source.children;
 	var AlignmentToolbar = wp.blocks.AlignmentToolbar;
 	var BlockControls = wp.blocks.BlockControls;
 

--- a/05-recipe-card-esnext/block.js
+++ b/05-recipe-card-esnext/block.js
@@ -3,7 +3,7 @@ const {
 	registerBlockType,
 	Editable,
 	MediaUploadButton,
-	query: {
+	source: {
 		children
 	}
 } = wp.blocks;

--- a/05-recipe-card/block.js
+++ b/05-recipe-card/block.js
@@ -1,7 +1,7 @@
 ( function( blocks, i18n, element, _ ) {
 	var el = element.createElement;
-	var query = blocks.query.query;
-	var children = blocks.query.children;
+	var query = blocks.source.query;
+	var children = blocks.source.children;
 
 	blocks.registerBlockType( 'gutenberg-examples/05-recipe-card', {
 		title: i18n.__( 'Example: Recipe Card' ),


### PR DESCRIPTION
This PR fixes several blocks for the `children` var by swapping by swapping `wp.blocks.query` with `wp.blocks.source`.

MERGES #2 

@aduth I created a clean and fresh PR. 