### PR TITLE
New wp.org handbook link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Examples for extending
 with plugins which create blocks.
 
 See also:
-[Gutenberg developer documentation](http://gutenberg-devdoc.surge.sh/)
+[Gutenberg developer documentation](https://wordpress.org/gutenberg/handbook/)


### PR DESCRIPTION
Changes the handbook link to the new wp.org location `https://wordpress.org/gutenberg/handbook/`