### PR TITLE
Update examples to work with latest release of Gutenberg

### DIFF
--- a/01-basic-esnext/block.js
+++ b/01-basic-esnext/block.js
@@ -7,7 +7,7 @@ const blockStyle = {
 	padding: '20px',
 };
 
-registerBlockType( 'gutenberg-examples/01-basic-esnext', {
+registerBlockType( 'gutenberg-examples/example-01-basic-esnext', {
 	title: __( 'Example: Basic (esnext)' ),
 	icon: 'universal-access-alt',
 	category: 'layout',

--- a/01-basic/block.js
+++ b/01-basic/block.js
@@ -16,7 +16,7 @@
 		padding: '20px'
 	};
 
-	blocks.registerBlockType( 'gutenberg-examples/01-basic', {
+	blocks.registerBlockType( 'gutenberg-examples/example-01-basic', {
 		title: __( 'Example: Basic', 'gutenberg-examples' ),
 		icon: 'universal-access-alt',
 		category: 'layout',

--- a/02-stylesheets/block.js
+++ b/02-stylesheets/block.js
@@ -11,7 +11,7 @@
 	var el = element.createElement;
 	var __ = i18n.__;
 
-	blocks.registerBlockType( 'gutenberg-examples/02-stylesheets', {
+	blocks.registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
 		title: __( 'Example: Stylesheets', 'gutenberg-examples' ),
 		icon: 'universal-access-alt',
 		category: 'layout',

--- a/02-stylesheets/editor.css
+++ b/02-stylesheets/editor.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *after* common styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-examples-02-stylesheets {
+.wp-block-gutenberg-examples-example-02-stylesheets {
 	color: green;
 	background: #cfc;
 	border: 2px solid #9c9;

--- a/02-stylesheets/style.css
+++ b/02-stylesheets/style.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *before* editor styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-examples-02-stylesheets {
+.wp-block-gutenberg-examples-example-02-stylesheets {
 	color: darkred;
 	background: #fcc;
 	border: 2px solid #c99;

--- a/03-editable-esnext/block.js
+++ b/03-editable-esnext/block.js
@@ -1,7 +1,7 @@
 const { __ } = wp.i18n;
 const { registerBlockType, Editable, source: { children } } = wp.blocks;
 
-registerBlockType( 'gutenberg-examples/03-editable-esnext', {
+registerBlockType( 'gutenberg-examples/example-03-editable-esnext', {
 	title: __( 'Example: Editable (esnext)' ),
 	icon: 'universal-access-alt',
 	category: 'layout',

--- a/03-editable-esnext/block.js
+++ b/03-editable-esnext/block.js
@@ -8,7 +8,8 @@ registerBlockType( 'gutenberg-examples/example-03-editable-esnext', {
 	attributes: {
 		content: {
 			type: 'array',
-			source: children( 'p' ),
+			source: 'children',
+			selector: 'p',
 		},
 	},
 	edit: props => {

--- a/03-editable-esnext/editor.css
+++ b/03-editable-esnext/editor.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *after* common styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-examples-03-editable-esnext {
+.wp-block-gutenberg-examples-example-03-editable-esnext {
 	color: green;
 	background: #cfc;
 	border: 2px solid #9c9;

--- a/03-editable-esnext/style.css
+++ b/03-editable-esnext/style.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *before* editor styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-examples-03-editable-esnext {
+.wp-block-gutenberg-examples-example-03-editable-esnext {
 	color: darkred;
 	background: #fcc;
 	border: 2px solid #c99;

--- a/03-editable/block.js
+++ b/03-editable/block.js
@@ -18,7 +18,8 @@
 		attributes: {
 			content: {
 				type: 'array',
-				source: children( 'p' ),
+				source: 'children',
+				selector: 'p',
 			},
 		},
 

--- a/03-editable/block.js
+++ b/03-editable/block.js
@@ -10,7 +10,7 @@
 	var Editable = blocks.Editable;
 	var children = blocks.source.children;
 
-	blocks.registerBlockType( 'gutenberg-examples/03-editable', {
+	blocks.registerBlockType( 'gutenberg-examples/example-03-editable', {
 		title: __( 'Example: Editable', 'gutenberg-examples' ),
 		icon: 'universal-access-alt',
 		category: 'layout',

--- a/03-editable/editor.css
+++ b/03-editable/editor.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *after* common styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-examples-03-editable {
+.wp-block-gutenberg-examples-example-03-editable {
 	color: green;
 	background: #cfc;
 	border: 2px solid #9c9;

--- a/03-editable/style.css
+++ b/03-editable/style.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *before* editor styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-examples-03-editable {
+.wp-block-gutenberg-examples-example-03-editable {
 	color: darkred;
 	background: #fcc;
 	border: 2px solid #c99;

--- a/04-controls-esnext/block.js
+++ b/04-controls-esnext/block.js
@@ -14,7 +14,8 @@ registerBlockType( 'gutenberg-examples/example-04-controls-esnext', {
 	attributes: {
 		content: {
 			type: 'array',
-			source: children( 'p' ),
+			source: 'children',
+			selector: 'p',
 		},
 	},
 	edit: props => {

--- a/04-controls-esnext/block.js
+++ b/04-controls-esnext/block.js
@@ -7,7 +7,7 @@ const {
 	BlockControls
 } = wp.blocks;
 
-registerBlockType( 'gutenberg-examples/04-controls-esnext', {
+registerBlockType( 'gutenberg-examples/example-04-controls-esnext', {
 	title: __( 'Example: Controls (esnext)' ),
 	icon: 'universal-access-alt',
 	category: 'layout',

--- a/04-controls-esnext/editor.css
+++ b/04-controls-esnext/editor.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *after* common styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-examples-04-controls-esnext {
+.wp-block-gutenberg-examples-example-04-controls-esnext {
 	color: #fff;
 	background: #00a8db;
 	border: 2px solid #0D72B2;

--- a/04-controls-esnext/style.css
+++ b/04-controls-esnext/style.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *before* editor styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-examples-04-controls-esnext {
+.wp-block-gutenberg-examples-example-04-controls-esnext {
 	color: #fff;
 	background: #00a8db;
 	border: 2px solid #0D72B2;

--- a/04-controls/block.js
+++ b/04-controls/block.js
@@ -19,7 +19,8 @@
 		attributes: {
 			content: {
 				type: 'array',
-				source: children( 'p' ),
+				source: 'children',
+				selector: 'p',
 			},
 		},
 

--- a/04-controls/block.js
+++ b/04-controls/block.js
@@ -11,7 +11,7 @@
 	var AlignmentToolbar = wp.blocks.AlignmentToolbar;
 	var BlockControls = wp.blocks.BlockControls;
 
-	blocks.registerBlockType( 'gutenberg-examples/04-controls', {
+	blocks.registerBlockType( 'gutenberg-examples/example-04-controls', {
 		title: __( 'Example: Controls', 'gutenberg-examples' ),
 		icon: 'universal-access-alt',
 		category: 'layout',

--- a/04-controls/editor.css
+++ b/04-controls/editor.css
@@ -2,9 +2,10 @@
  * Note that these styles are loaded *after* common styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-boilerplate-es5-04-controls {
-	color: green;
-	background: #cfc;
-	border: 2px solid #9c9;
+.wp-block-gutenberg-examples-example-04-controls-esnext {
+	color: #fff;
+	background: #00a8db;
+	border: 2px solid #0D72B2;
 	padding: 20px;
+	font-family: sans-serif;
 }

--- a/05-recipe-card-esnext/block.js
+++ b/05-recipe-card-esnext/block.js
@@ -9,7 +9,7 @@ const {
 	}
 } = wp.blocks;
 
-registerBlockType( 'gutenberg-examples/05-recipe-card-esnext', {
+registerBlockType( 'gutenberg-examples/example-05-recipe-card-esnext', {
 	title: __( 'Example: Recipe Card (esnext)' ),
 	icon: 'index-card',
 	category: 'layout',

--- a/05-recipe-card-esnext/block.js
+++ b/05-recipe-card-esnext/block.js
@@ -16,22 +16,27 @@ registerBlockType( 'gutenberg-examples/example-05-recipe-card-esnext', {
 	attributes: {
 		title: {
 			type: 'array',
-			source: children( 'h2' ),
+			source: 'children',
+			selector: 'h2',
 		},
 		mediaID: {
 			type: 'number',
 		},
 		mediaURL: {
 			type: 'string',
-			source: attr( 'img', 'src' ),
+			source: 'attribute',
+			selector: 'img',
+			attribute: 'src',
 		},
 		ingredients: {
 			type: 'array',
-			source: children( '.ingredients' ),
+			source: 'children',
+			selector: '.ingredients',
 		},
 		instructions: {
 			type: 'array',
-			source: children( '.steps' ),
+			source: 'children',
+			selector: '.steps',
 		},
 	},
 	edit: props => {

--- a/05-recipe-card-esnext/style.css
+++ b/05-recipe-card-esnext/style.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *before* editor styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-examples-05-recipe-card-esnext .recipe-image {
+.wp-block-gutenberg-examples-example-05-recipe-card-esnext .recipe-image {
 	background: #f1f1f1;
 	float: right;
 	width: 50%;
@@ -10,26 +10,26 @@
 	text-align: center;
 }
 
-.wp-block-gutenberg-examples-05-recipe-card-esnext .recipe-image button {
+.wp-block-gutenberg-examples-example-05-recipe-card-esnext .recipe-image button {
 	margin-top: 30px;
 }
 
-.wp-block-gutenberg-examples-05-recipe-card-esnext .recipe-image button.image-button {
+.wp-block-gutenberg-examples-example-05-recipe-card-esnext .recipe-image button.image-button {
 	margin: 0;
 	padding: 0;
 	display: block;
 }
 
-.wp-block-gutenberg-examples-05-recipe-card-esnext .recipe-image img {
+.wp-block-gutenberg-examples-example-05-recipe-card-esnext .recipe-image img {
 	display: block;
 	z-index: 1;
 	position: relative;
 }
 
-.wp-block-gutenberg-examples-05-recipe-card-esnext h2 {
+.wp-block-gutenberg-examples-example-05-recipe-card-esnext h2 {
 	font-size: 1.5em;
 }
 
-.wp-block-gutenberg-examples-05-recipe-card-esnext ul {
+.wp-block-gutenberg-examples-example-05-recipe-card-esnext ul {
 	padding-left: 2.5em !important; /* Needs fix in Gutenberg. */
 }

--- a/05-recipe-card/block.js
+++ b/05-recipe-card/block.js
@@ -3,7 +3,7 @@
 	var children = blocks.source.children;
 	var attr = blocks.source.attr;
 
-	blocks.registerBlockType( 'gutenberg-examples/05-recipe-card', {
+	blocks.registerBlockType( 'gutenberg-examples/example-05-recipe-card', {
 		title: i18n.__( 'Example: Recipe Card' ),
 		icon: 'index-card',
 		category: 'layout',

--- a/05-recipe-card/block.js
+++ b/05-recipe-card/block.js
@@ -10,22 +10,27 @@
 		attributes: {
 			title: {
 				type: 'array',
-				source: children( 'h2' ),
+				source: 'children',
+				selector: 'h2',
 			},
 			mediaID: {
 				type: 'number',
 			},
 			mediaURL: {
 				type: 'string',
-				source: attr( 'img', 'src' ),
+				source: 'attribute',
+				selector: 'img',
+				attribute: 'src',
 			},
 			ingredients: {
 				type: 'array',
-				source: children( '.ingredients' ),
+				source: 'children',
+				selector: '.ingredients',
 			},
 			instructions: {
 				type: 'array',
-				source: children( '.steps' ),
+				source: 'children',
+				selector: '.steps',
 			},
 		},
 		edit: function( props ) {

--- a/05-recipe-card/style.css
+++ b/05-recipe-card/style.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *before* editor styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-examples-05-recipe-card .recipe-image {
+.wp-block-gutenberg-examples-example-05-recipe-card .recipe-image {
 	background: #f1f1f1;
 	float: right;
 	width: 50%;
@@ -10,26 +10,26 @@
 	text-align: center;
 }
 
-.wp-block-gutenberg-examples-05-recipe-card .recipe-image button {
+.wp-block-gutenberg-examples-example-05-recipe-card .recipe-image button {
 	margin-top: 30px;
 }
 
-.wp-block-gutenberg-examples-05-recipe-card .recipe-image button.image-button {
+.wp-block-gutenberg-examples-example-05-recipe-card .recipe-image button.image-button {
 	margin: 0;
 	padding: 0;
 	display: block;
 }
 
-.wp-block-gutenberg-examples-05-recipe-card .recipe-image img {
+.wp-block-gutenberg-examples-example-05-recipe-card .recipe-image img {
 	display: block;
 	z-index: 1;
 	position: relative;
 }
 
-.wp-block-gutenberg-examples-05-recipe-card h2 {
+.wp-block-gutenberg-examples-example-05-recipe-card h2 {
 	font-size: 1.5em;
 }
 
-.wp-block-gutenberg-examples-05-recipe-card ul {
+.wp-block-gutenberg-examples-example-05-recipe-card ul {
 	padding-left: 2.5em !important; /* Needs fix in Gutenberg. */
 }


### PR DESCRIPTION
Fixes #8. Also fixes `"Attributes matchers are deprecated and they will be removed in a future version of Gutenberg"` warning.