### PR TITLE
filemtime() failing, causing PHP warnings

### DIFF
--- a/01-basic-esnext/index.php
+++ b/01-basic-esnext/index.php
@@ -7,8 +7,8 @@ add_action( 'enqueue_block_editor_assets', 'gutenberg_examples_01_esnext_enqueue
 function gutenberg_examples_01_esnext_enqueue_block_editor_assets() {
 	wp_enqueue_script(
 		'gutenberg-examples-01-esnext',
-		plugins_url( 'block.build.js', __FILE__ ),
+		plugins_url( 'block.js', __FILE__ ),
 		array( 'wp-blocks', 'wp-i18n', 'wp-element' ),
-		filemtime( plugin_dir_path( __FILE__ ) . 'block.build.js' )
+		filemtime( plugin_dir_path( __FILE__ ) . 'block.js' )
 	);
 }

--- a/01-basic-esnext/webpack.config.js
+++ b/01-basic-esnext/webpack.config.js
@@ -2,7 +2,7 @@ module.exports = {
 	entry: './block.js',
 	output: {
 		path: __dirname,
-		filename: 'block.build.js',
+		filename: 'block.js',
 	},
 	module: {
 		loaders: [

--- a/03-editable-esnext/index.php
+++ b/03-editable-esnext/index.php
@@ -7,9 +7,9 @@ add_action( 'enqueue_block_editor_assets', 'gutenberg_examples_03_esnext_enqueue
 function gutenberg_examples_03_esnext_enqueue_block_editor_assets() {
 	wp_enqueue_script(
 		'gutenberg-examples-03_esnext',
-		plugins_url( 'block.build.js', __FILE__ ),
+		plugins_url( 'block.js', __FILE__ ),
 		array( 'wp-blocks', 'wp-i18n', 'wp-element' ),
-		filemtime( plugin_dir_path( __FILE__ ) . 'block.build.js' )
+		filemtime( plugin_dir_path( __FILE__ ) . 'block.js' )
 	);
 
 	wp_enqueue_style(

--- a/03-editable-esnext/webpack.config.js
+++ b/03-editable-esnext/webpack.config.js
@@ -2,7 +2,7 @@ module.exports = {
 	entry: './block.js',
 	output: {
 		path: __dirname,
-		filename: 'block.build.js',
+		filename: 'block.js',
 	},
 	module: {
 		loaders: [

--- a/04-controls-esnext/index.php
+++ b/04-controls-esnext/index.php
@@ -7,9 +7,9 @@ add_action( 'enqueue_block_editor_assets', 'gutenberg_examples_04_esnext_enqueue
 function gutenberg_examples_04_esnext_enqueue_block_editor_assets() {
 	wp_enqueue_script(
 		'gutenberg-examples-04_esnext',
-		plugins_url( 'block.build.js', __FILE__ ),
+		plugins_url( 'block.js', __FILE__ ),
 		array( 'wp-blocks', 'wp-i18n', 'wp-element' ),
-		filemtime( plugin_dir_path( __FILE__ ) . 'block.build.js' )
+		filemtime( plugin_dir_path( __FILE__ ) . 'block.js' )
 	);
 
 	wp_enqueue_style(

--- a/04-controls-esnext/webpack.config.js
+++ b/04-controls-esnext/webpack.config.js
@@ -4,7 +4,7 @@ var webpack = require( 'webpack' ),
 	entry: './block.js',
 	output: {
 		path: __dirname,
-		filename: 'block.build.js',
+		filename: 'block.js',
 	},
 	module: {
 		loaders: [

--- a/05-recipe-card-esnext/index.php
+++ b/05-recipe-card-esnext/index.php
@@ -7,9 +7,9 @@ add_action( 'enqueue_block_editor_assets', 'gutenberg_examples_05_esnext_enqueue
 function gutenberg_examples_05_esnext_enqueue_block_editor_assets() {
 	wp_enqueue_script(
 		'gutenberg-examples-05_esnext',
-		plugins_url( 'block.build.js', __FILE__ ),
+		plugins_url( 'block.js', __FILE__ ),
 		array( 'wp-blocks', 'wp-i18n', 'wp-element', 'underscore' ),
-		filemtime( plugin_dir_path( __FILE__ ) . 'block.build.js' )
+		filemtime( plugin_dir_path( __FILE__ ) . 'block.js' )
 	);
 }
 

--- a/05-recipe-card-esnext/webpack.config.js
+++ b/05-recipe-card-esnext/webpack.config.js
@@ -4,7 +4,7 @@ var webpack = require( 'webpack' ),
 	entry: './block.js',
 	output: {
 		path: __dirname,
-		filename: 'block.build.js',
+		filename: 'block.js',
 	},
 	module: {
 		loaders: [


### PR DESCRIPTION
Thanks for these helpful examples. I found that the block.build.js file is referenced several times in the ESNext-based examples, but it doesn't exist in the plugin, so PHP is throwing a few warnings. I updated all instances to reference _block.js_ instead. Warnings gone.