### PR TITLE
Add `GPL-2.0-or-later` license to `package.json`

### DIFF
--- a/01-basic-esnext/package.json
+++ b/01-basic-esnext/package.json
@@ -1,6 +1,7 @@
 {
   "name": "01-basic-esnext",
   "version": "1.0.0",
+  "license": "GPL-2.0-or-later",
   "main": "block.js",
   "devDependencies": {
     "babel-core": "^6.25.0",

--- a/03-editable-esnext/package.json
+++ b/03-editable-esnext/package.json
@@ -1,6 +1,7 @@
 {
   "name": "03-editable-esnext",
   "version": "1.0.0",
+  "license": "GPL-2.0-or-later",
   "main": "block.js",
   "devDependencies": {
     "babel-core": "^6.25.0",

--- a/04-controls-esnext/package.json
+++ b/04-controls-esnext/package.json
@@ -1,6 +1,7 @@
 {
   "name": "04-controls-esnext",
   "version": "1.0.0",
+  "license": "GPL-2.0-or-later",
   "main": "block.js",
   "devDependencies": {
     "babel-core": "^6.25.0",

--- a/05-recipe-card-esnext/package.json
+++ b/05-recipe-card-esnext/package.json
@@ -1,6 +1,7 @@
 {
   "name": "04-controls-esnext",
   "version": "1.0.0",
+  "license": "GPL-2.0-or-later",
   "main": "block.js",
   "devDependencies": {
     "babel-core": "^6.25.0",


### PR DESCRIPTION
Only 4 examples include a `package.json` file, they were all missing the `license` field.

See also:
• https://spdx.org/news/news/2018/01/license-list-30-released
• https://spdx.org/licenses/
• WordPress Ticket [#43032](https://core.trac.wordpress.org/ticket/43032)