### PR TITLE
Replace wp.blocks.Editable to wp.blocks.RichText

### DIFF
--- a/03-editable-esnext/block.js
+++ b/03-editable-esnext/block.js
@@ -1,5 +1,5 @@
 const { __ } = wp.i18n;
-const { registerBlockType, Editable, source: { children } } = wp.blocks;
+const { registerBlockType, RichText, source: { children } } = wp.blocks;
 
 registerBlockType( 'gutenberg-examples/example-03-editable-esnext', {
 	title: __( 'Example: Editable (esnext)' ),
@@ -18,7 +18,7 @@ registerBlockType( 'gutenberg-examples/example-03-editable-esnext', {
 			props.setAttributes( { content: newContent } );
 		};
 		return (
-			<Editable
+			<RichText
 				className={ className }
 				onChange={ onChangeContent }
 				value={ content }

--- a/03-editable/block.js
+++ b/03-editable/block.js
@@ -2,12 +2,12 @@
  * Hello World: Step 3
  *
  * Editable "Hello World" text.  Introduces the concept of attributes and
- * extracting them, and the default text formatting added by Editable.
+ * extracting them, and the default text formatting added by RichText.
  */
 ( function( blocks, i18n, element ) {
 	var el = element.createElement;
 	var __ = i18n.__;
-	var Editable = blocks.Editable;
+	var RichText = blocks.RichText;
 	var children = blocks.source.children;
 
 	blocks.registerBlockType( 'gutenberg-examples/example-03-editable', {
@@ -31,7 +31,7 @@
 			}
 
 			return el(
-				Editable,
+				RichText,
 				{
 					tagName: 'p',
 					className: props.className,

--- a/04-controls-esnext/block.js
+++ b/04-controls-esnext/block.js
@@ -1,7 +1,7 @@
 const { __ } = wp.i18n;
 const {
 	registerBlockType,
-	Editable,
+	RichText,
 	source: { children },
 	AlignmentToolbar,
 	BlockControls
@@ -49,7 +49,7 @@ registerBlockType( 'gutenberg-examples/example-04-controls-esnext', {
 						</BlockControls>
 					)
 				}
-				<Editable
+				<RichText
 					className={ className }
 					style={ { textAlign: alignment } }
 					onChange={ onChangeContent }

--- a/04-controls/block.js
+++ b/04-controls/block.js
@@ -6,7 +6,7 @@
 ( function( blocks, i18n, element ) {
 	var el = element.createElement;
 	var __ = i18n.__;
-	var Editable = blocks.Editable;
+	var RichText = blocks.RichText;
 	var children = blocks.source.children;
 	var AlignmentToolbar = wp.blocks.AlignmentToolbar;
 	var BlockControls = wp.blocks.BlockControls;
@@ -50,7 +50,7 @@
 					)
 				),
 				el(
-					Editable,
+					RichText,
 					{
 						key: 'editable',
 						tagName: 'p',

--- a/05-recipe-card-esnext/block.js
+++ b/05-recipe-card-esnext/block.js
@@ -1,7 +1,7 @@
 const { __ } = wp.i18n;
 const {
 	registerBlockType,
-	Editable,
+	RichText,
 	MediaUpload,
 	source: {
 		attr,
@@ -70,7 +70,7 @@ registerBlockType( 'gutenberg-examples/example-05-recipe-card-esnext', {
 
 		return (
 			<div className={ props.className }>
-				<Editable
+				<RichText
 					tagName="h2"
 					placeholder={ __( 'Write Recipe title…' ) }
 					value={ attributes.title }
@@ -91,7 +91,7 @@ registerBlockType( 'gutenberg-examples/example-05-recipe-card-esnext', {
 					/>
 				</div>
 				<h3>{ __( 'Ingredients' ) }</h3>
-				<Editable
+				<RichText
 					tagName="ul"
 					multiline="li"
 					placeholder={ __( 'Write a list of ingredients…' ) }
@@ -102,7 +102,7 @@ registerBlockType( 'gutenberg-examples/example-05-recipe-card-esnext', {
 					className="ingredients"
 				/>
 				<h3>{ __( 'Instructions' ) }</h3>
-				<Editable
+				<RichText
 					tagName="div"
 					multiline="p"
 					className="steps"

--- a/05-recipe-card/block.js
+++ b/05-recipe-card/block.js
@@ -44,7 +44,7 @@
 
 			return (
 				el( 'div', { className: props.className },
-					el( blocks.Editable, {
+					el( blocks.RichText, {
 						tagName: 'h2',
 						inline: true,
 						placeholder: i18n.__( 'Write Recipe title…' ),
@@ -73,7 +73,7 @@
 						} )
 					),
 					el( 'h3', {}, i18n.__( 'Ingredients' ) ),
-					el( blocks.Editable, {
+					el( blocks.RichText, {
 						tagName: 'ul',
 						multiline: 'li',
 						placeholder: i18n.__( 'Write a list of ingredients…' ),
@@ -88,7 +88,7 @@
 						className: 'ingredients',
 					} ),
 					el( 'h3', {}, i18n.__( 'Instructions' ) ),
-					el( blocks.Editable, {
+					el( blocks.RichText, {
 						tagName: 'div',
 						inline: false,
 						placeholder: i18n.__( 'Write instructions…' ),


### PR DESCRIPTION
`wp.blocks.Editable` is deprecated and throws the following warning

```
index.js?ver=1517805540:12 Editable is deprecated, use wp.blocks.RichText instead.
```

This PR replace all `wp.blocks.Editable` to `wp.blocks.RichText`