### PR TITLE
Example 04 Controls CSS Naming fix

### DIFF
--- a/04-controls/editor.css
+++ b/04-controls/editor.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *after* common styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-examples-example-04-controls-esnext {
+.wp-block-gutenberg-examples-example-04-controls {
 	color: #fff;
 	background: #00a8db;
 	border: 2px solid #0D72B2;

--- a/04-controls/style.css
+++ b/04-controls/style.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *before* editor styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-examples-04-controls {
+.wp-block-gutenberg-examples-example-04-controls {
 	color: darkred;
 	background: #fcc;
 	border: 2px solid #c99;


### PR DESCRIPTION
In case of example 04 controls , the CSS styles are not reflected in back end editor as well as front due to mistake in naming of CSS classes in editor.css and style.css

