### PR TITLE
Add plugin manifest to each example

### DIFF
--- a/01-basic-esnext/index.php
+++ b/01-basic-esnext/index.php
@@ -1,5 +1,15 @@
 <?php
 
+/**
+ * Plugin Name: Gutenberg Examples Basic EsNext
+ * Plugin URI: https://github.com/WordPress/gutenberg-examples
+ * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
+ * Version: 0.1.0
+ * Author: the Gutenberg Team
+ *
+ * @package gutenberg-examples
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/01-basic-esnext/index.php
+++ b/01-basic-esnext/index.php
@@ -4,7 +4,7 @@
  * Plugin Name: Gutenberg Examples Basic EsNext
  * Plugin URI: https://github.com/WordPress/gutenberg-examples
  * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
- * Version: 0.1.0
+ * Version: 1.0.2
  * Author: the Gutenberg Team
  *
  * @package gutenberg-examples

--- a/01-basic/index.php
+++ b/01-basic/index.php
@@ -1,5 +1,15 @@
 <?php
 
+/**
+ * Plugin Name: Gutenberg Examples Basic
+ * Plugin URI: https://github.com/WordPress/gutenberg-examples
+ * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
+ * Version: 0.1.0
+ * Author: the Gutenberg Team
+ *
+ * @package gutenberg-examples
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/01-basic/index.php
+++ b/01-basic/index.php
@@ -4,7 +4,7 @@
  * Plugin Name: Gutenberg Examples Basic
  * Plugin URI: https://github.com/WordPress/gutenberg-examples
  * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
- * Version: 0.1.0
+ * Version: 1.0.2
  * Author: the Gutenberg Team
  *
  * @package gutenberg-examples

--- a/02-stylesheets/index.php
+++ b/02-stylesheets/index.php
@@ -4,7 +4,7 @@
  * Plugin Name: Gutenberg Examples Stylesheets
  * Plugin URI: https://github.com/WordPress/gutenberg-examples
  * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
- * Version: 0.1.0
+ * Version: 1.0.2
  * Author: the Gutenberg Team
  *
  * @package gutenberg-examples

--- a/02-stylesheets/index.php
+++ b/02-stylesheets/index.php
@@ -1,5 +1,15 @@
 <?php
 
+/**
+ * Plugin Name: Gutenberg Examples Stylesheets
+ * Plugin URI: https://github.com/WordPress/gutenberg-examples
+ * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
+ * Version: 0.1.0
+ * Author: the Gutenberg Team
+ *
+ * @package gutenberg-examples
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/03-editable-esnext/index.php
+++ b/03-editable-esnext/index.php
@@ -4,7 +4,7 @@
  * Plugin Name: Gutenberg Examples Editable EsNext
  * Plugin URI: https://github.com/WordPress/gutenberg-examples
  * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
- * Version: 0.1.0
+ * Version: 1.0.2
  * Author: the Gutenberg Team
  *
  * @package gutenberg-examples

--- a/03-editable-esnext/index.php
+++ b/03-editable-esnext/index.php
@@ -1,5 +1,15 @@
 <?php
 
+/**
+ * Plugin Name: Gutenberg Examples Editable EsNext
+ * Plugin URI: https://github.com/WordPress/gutenberg-examples
+ * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
+ * Version: 0.1.0
+ * Author: the Gutenberg Team
+ *
+ * @package gutenberg-examples
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/03-editable-esnext/package-lock.json
+++ b/03-editable-esnext/package-lock.json
@@ -1856,7 +1856,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2271,7 +2272,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2327,6 +2329,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2370,12 +2373,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/03-editable/index.php
+++ b/03-editable/index.php
@@ -4,23 +4,11 @@
  * Plugin Name: Gutenberg Examples Editable
  * Plugin URI: https://github.com/WordPress/gutenberg-examples
  * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
- * Version: 0.1.0
+ * Version: 1.0.2
  * Author: the Gutenberg Team
  *
  * @package gutenberg-examples
  */
-
-
-/**
- * Plugin Name: Gutenberg Examples Controls EsNext
- * Plugin URI: https://github.com/WordPress/gutenberg-examples
- * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
- * Version: 0.1.0
- * Author: the Gutenberg Team
- *
- * @package gutenberg-examples
- */
-
 
 defined( 'ABSPATH' ) || exit;
 

--- a/03-editable/index.php
+++ b/03-editable/index.php
@@ -1,5 +1,27 @@
 <?php
 
+/**
+ * Plugin Name: Gutenberg Examples Editable
+ * Plugin URI: https://github.com/WordPress/gutenberg-examples
+ * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
+ * Version: 0.1.0
+ * Author: the Gutenberg Team
+ *
+ * @package gutenberg-examples
+ */
+
+
+/**
+ * Plugin Name: Gutenberg Examples Controls EsNext
+ * Plugin URI: https://github.com/WordPress/gutenberg-examples
+ * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
+ * Version: 0.1.0
+ * Author: the Gutenberg Team
+ *
+ * @package gutenberg-examples
+ */
+
+
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/04-controls-esnext/index.php
+++ b/04-controls-esnext/index.php
@@ -1,5 +1,15 @@
 <?php
 
+/**
+ * Plugin Name: Gutenberg Examples Controls EsNext
+ * Plugin URI: https://github.com/WordPress/gutenberg-examples
+ * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
+ * Version: 0.1.0
+ * Author: the Gutenberg Team
+ *
+ * @package gutenberg-examples
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/04-controls-esnext/index.php
+++ b/04-controls-esnext/index.php
@@ -4,7 +4,7 @@
  * Plugin Name: Gutenberg Examples Controls EsNext
  * Plugin URI: https://github.com/WordPress/gutenberg-examples
  * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
- * Version: 0.1.0
+ * Version: 1.0.2
  * Author: the Gutenberg Team
  *
  * @package gutenberg-examples

--- a/04-controls/index.php
+++ b/04-controls/index.php
@@ -1,5 +1,15 @@
 <?php
 
+/**
+ * Plugin Name: Gutenberg Examples Controls
+ * Plugin URI: https://github.com/WordPress/gutenberg-examples
+ * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
+ * Version: 0.1.0
+ * Author: the Gutenberg Team
+ *
+ * @package gutenberg-examples
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/04-controls/index.php
+++ b/04-controls/index.php
@@ -4,7 +4,7 @@
  * Plugin Name: Gutenberg Examples Controls
  * Plugin URI: https://github.com/WordPress/gutenberg-examples
  * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
- * Version: 0.1.0
+ * Version: 1.0.2
  * Author: the Gutenberg Team
  *
  * @package gutenberg-examples

--- a/05-recipe-card-esnext/index.php
+++ b/05-recipe-card-esnext/index.php
@@ -4,7 +4,7 @@
  * Plugin Name: Gutenberg Examples Recipe Card EsNext
  * Plugin URI: https://github.com/WordPress/gutenberg-examples
  * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
- * Version: 0.1.0
+ * Version: 1.0.2
  * Author: the Gutenberg Team
  *
  * @package gutenberg-examples

--- a/05-recipe-card-esnext/index.php
+++ b/05-recipe-card-esnext/index.php
@@ -1,5 +1,15 @@
 <?php
 
+/**
+ * Plugin Name: Gutenberg Examples Recipe Card EsNext
+ * Plugin URI: https://github.com/WordPress/gutenberg-examples
+ * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
+ * Version: 0.1.0
+ * Author: the Gutenberg Team
+ *
+ * @package gutenberg-examples
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/05-recipe-card/index.php
+++ b/05-recipe-card/index.php
@@ -1,5 +1,15 @@
 <?php
 
+/**
+ * Plugin Name: Gutenberg Examples Recipe Card
+ * Plugin URI: https://github.com/WordPress/gutenberg-examples
+ * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
+ * Version: 0.1.0
+ * Author: the Gutenberg Team
+ *
+ * @package gutenberg-examples
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/05-recipe-card/index.php
+++ b/05-recipe-card/index.php
@@ -4,7 +4,7 @@
  * Plugin Name: Gutenberg Examples Recipe Card
  * Plugin URI: https://github.com/WordPress/gutenberg-examples
  * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
- * Version: 0.1.0
+ * Version: 1.0.2
  * Author: the Gutenberg Team
  *
  * @package gutenberg-examples

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
  * Plugin Name: Gutenberg Examples
  * Plugin URI: https://github.com/WordPress/gutenberg-examples
  * Description: This is a plugin demonstrating how to register new blocks for the Gutenberg editor.
- * Version: 0.1.0
+ * Version: 1.0.2
  * Author: the Gutenberg Team
  *
  * @package gutenberg-examples


### PR DESCRIPTION
 Plugin manifest added to all examples for independent usage 

Reference https://github.com/WordPress/gutenberg-examples/issues/36#issuecomment-416212869