### PR TITLE
Load scripts only in the editor

### DIFF
--- a/01-basic-esnext/index.php
+++ b/01-basic-esnext/index.php
@@ -32,7 +32,7 @@ function gutenberg_examples_01_esnext_register_block() {
 	);
 
 	register_block_type( 'gutenberg-examples/example-01-basic-esnext', array(
-		'script' => 'gutenberg-examples-01-esnext',
+		'editor_script' => 'gutenberg-examples-01-esnext',
 	) );
 
 	/*
@@ -42,12 +42,12 @@ function gutenberg_examples_01_esnext_register_block() {
 	 */
 	wp_add_inline_script(
 		'gutenberg-examples-01-esnext',
-		sprintf( 
-			'var gutenberg_examples_01_esnext = { localeData: %s };', 
+		sprintf(
+			'var gutenberg_examples_01_esnext = { localeData: %s };',
 			json_encode( ! function_exists( 'wp_get_jed_locale_data' ) ? gutenberg_get_jed_locale_data( 'gutenberg-examples' ) : wp_get_jed_locale_data( 'gutenberg-examples' ) )
 		),
 		'before'
 	);
 
-} 
+}
 add_action( 'init', 'gutenberg_examples_01_esnext_register_block' );

--- a/01-basic/index.php
+++ b/01-basic/index.php
@@ -32,7 +32,7 @@ function gutenberg_examples_01_register_block() {
 	);
 
 	register_block_type( 'gutenberg-examples/example-01-basic', array(
-		'script' => 'gutenberg-examples-01',
+		'editor_script' => 'gutenberg-examples-01',
 	) );
 
 	/*
@@ -42,12 +42,12 @@ function gutenberg_examples_01_register_block() {
 	 */
 	wp_add_inline_script(
 		'gutenberg-examples-01',
-		sprintf( 
-			'var gutenberg_examples_01 = { localeData: %s };', 
+		sprintf(
+			'var gutenberg_examples_01 = { localeData: %s };',
 			json_encode( ! function_exists( 'wp_get_jed_locale_data' ) ? gutenberg_get_jed_locale_data( 'gutenberg-examples' ) : wp_get_jed_locale_data( 'gutenberg-examples' ) )
 		),
 		'before'
 	);
 
-} 
+}
 add_action( 'init', 'gutenberg_examples_01_register_block' );

--- a/02-stylesheets/index.php
+++ b/02-stylesheets/index.php
@@ -48,7 +48,7 @@ function gutenberg_examples_02_register_block() {
 	register_block_type( 'gutenberg-examples/example-02-stylesheets', array(
 		'style' => 'gutenberg-examples-02',
 		'editor_style' => 'gutenberg-examples-02-editor',
-		'script' => 'gutenberg-examples-02',
+		'editor_script' => 'gutenberg-examples-02',
 	) );
 
 	/*
@@ -62,5 +62,5 @@ function gutenberg_examples_02_register_block() {
 		'before'
 	);
 
-} 
+}
 add_action( 'init', 'gutenberg_examples_02_register_block' );

--- a/03-editable-esnext/index.php
+++ b/03-editable-esnext/index.php
@@ -48,7 +48,7 @@ function gutenberg_examples_03_esnext_register_block() {
 	register_block_type( 'gutenberg-examples/example-03-editable-esnext', array(
 		'style' => 'gutenberg-examples-03-esnext',
 		'editor_style' => 'gutenberg-examples-03-esnext-editor',
-		'script' => 'gutenberg-examples-03-esnext',
+		'editor_script' => 'gutenberg-examples-03-esnext',
 	) );
 
 	/*
@@ -58,12 +58,12 @@ function gutenberg_examples_03_esnext_register_block() {
 	 */
 	wp_add_inline_script(
 		'gutenberg-examples-03-esnext',
-		sprintf( 
-			'var gutenberg_examples_03_esnext = { localeData: %s };', 
+		sprintf(
+			'var gutenberg_examples_03_esnext = { localeData: %s };',
 			json_encode( ! function_exists( 'wp_get_jed_locale_data' ) ? gutenberg_get_jed_locale_data( 'gutenberg-examples' ) : wp_get_jed_locale_data( 'gutenberg-examples' ) )
 		),
 		'before'
 	);
 
-} 
+}
 add_action( 'init', 'gutenberg_examples_03_esnext_register_block' );

--- a/03-editable/index.php
+++ b/03-editable/index.php
@@ -48,7 +48,7 @@ function gutenberg_examples_03_register_block() {
 	register_block_type( 'gutenberg-examples/example-03-editable', array(
 		'style' => 'gutenberg-examples-03',
 		'editor_style' => 'gutenberg-examples-03-editor',
-		'script' => 'gutenberg-examples-03',
+		'editor_script' => 'gutenberg-examples-03',
 	) );
 
 	/*
@@ -58,12 +58,12 @@ function gutenberg_examples_03_register_block() {
 	 */
 	wp_add_inline_script(
 		'gutenberg-examples-03',
-		sprintf( 
-			'var gutenberg_examples_03 = { localeData: %s };', 
+		sprintf(
+			'var gutenberg_examples_03 = { localeData: %s };',
 			json_encode( ! function_exists( 'wp_get_jed_locale_data' ) ? gutenberg_get_jed_locale_data( 'gutenberg-examples' ) : wp_get_jed_locale_data( 'gutenberg-examples' ) )
 		),
 		'before'
 	);
 
-} 
+}
 add_action( 'init', 'gutenberg_examples_03_register_block' );

--- a/04-controls-esnext/index.php
+++ b/04-controls-esnext/index.php
@@ -23,7 +23,7 @@ function gutenberg_examples_04_esnext_register_block() {
 		// Gutenberg is not active.
 		return;
 	}
-	
+
 	wp_register_script(
 		'gutenberg-examples-04-esnext',
 		plugins_url( 'block.build.js', __FILE__ ),
@@ -48,7 +48,7 @@ function gutenberg_examples_04_esnext_register_block() {
 	register_block_type( 'gutenberg-examples/example-04-controls-esnext', array(
 		'style' => 'gutenberg-examples-04-esnext',
 		'editor_style' => 'gutenberg-examples-04-esnext-editor',
-		'script' => 'gutenberg-examples-04-esnext',
+		'editor_script' => 'gutenberg-examples-04-esnext',
 	) );
 
 	/*
@@ -58,12 +58,12 @@ function gutenberg_examples_04_esnext_register_block() {
 	 */
 	wp_add_inline_script(
 		'gutenberg-examples-04-esnext',
-		sprintf( 
-			'var gutenberg_examples_04_esnext = { localeData: %s };', 
+		sprintf(
+			'var gutenberg_examples_04_esnext = { localeData: %s };',
 			json_encode( ! function_exists( 'wp_get_jed_locale_data' ) ? gutenberg_get_jed_locale_data( 'gutenberg-examples' ) : wp_get_jed_locale_data( 'gutenberg-examples' ) )
 		),
 		'before'
 	);
 
-} 
+}
 add_action( 'init', 'gutenberg_examples_04_esnext_register_block' );

--- a/04-controls/index.php
+++ b/04-controls/index.php
@@ -48,7 +48,7 @@ function gutenberg_examples_04_register_block() {
 	register_block_type( 'gutenberg-examples/example-04-controls', array(
 		'style' => 'gutenberg-examples-04',
 		'editor_style' => 'gutenberg-examples-04-editor',
-		'script' => 'gutenberg-examples-04',
+		'editor_script' => 'gutenberg-examples-04',
 	) );
 
 	/*
@@ -58,12 +58,12 @@ function gutenberg_examples_04_register_block() {
 	 */
 	wp_add_inline_script(
 		'gutenberg-examples-04',
-		sprintf( 
-			'var gutenberg_examples_04 = { localeData: %s };', 
+		sprintf(
+			'var gutenberg_examples_04 = { localeData: %s };',
 			json_encode( ! function_exists( 'wp_get_jed_locale_data' ) ? gutenberg_get_jed_locale_data( 'gutenberg-examples' ) : wp_get_jed_locale_data( 'gutenberg-examples' ) )
 		),
 		'before'
 	);
 
-} 
+}
 add_action( 'init', 'gutenberg_examples_04_register_block' );

--- a/05-recipe-card-esnext/index.php
+++ b/05-recipe-card-esnext/index.php
@@ -40,7 +40,7 @@ function gutenberg_examples_05_esnext_register_block() {
 
 	register_block_type( 'gutenberg-examples/example-05-recipe-card-esnext', array(
 		'style' => 'gutenberg-examples-05-esnext',
-		'script' => 'gutenberg-examples-05-esnext',
+		'editor_script' => 'gutenberg-examples-05-esnext',
 	) );
 
 	/*
@@ -50,12 +50,12 @@ function gutenberg_examples_05_esnext_register_block() {
 	 */
 	wp_add_inline_script(
 		'gutenberg-examples-05-esnext',
-		sprintf( 
-			'var gutenberg_examples_05_esnext = { localeData: %s };', 
+		sprintf(
+			'var gutenberg_examples_05_esnext = { localeData: %s };',
 			json_encode( ! function_exists( 'wp_get_jed_locale_data' ) ? gutenberg_get_jed_locale_data( 'gutenberg-examples' ) : wp_get_jed_locale_data( 'gutenberg-examples' ) )
 		),
 		'before'
 	);
 
-} 
+}
 add_action( 'init', 'gutenberg_examples_05_esnext_register_block' );

--- a/05-recipe-card/index.php
+++ b/05-recipe-card/index.php
@@ -23,7 +23,7 @@ function gutenberg_examples_05_register_block() {
 		// Gutenberg is not active.
 		return;
 	}
-	
+
 	wp_register_script(
 		'gutenberg-examples-05',
 		plugins_url( 'block.js', __FILE__ ),
@@ -40,7 +40,7 @@ function gutenberg_examples_05_register_block() {
 
 	register_block_type( 'gutenberg-examples/example-05-recipe-card', array(
 		'style' => 'gutenberg-examples-05',
-		'script' => 'gutenberg-examples-05',
+		'editor_script' => 'gutenberg-examples-05',
 	) );
 
 	/*
@@ -50,12 +50,12 @@ function gutenberg_examples_05_register_block() {
 	 */
 	wp_add_inline_script(
 		'gutenberg-examples-05',
-		sprintf( 
-			'var gutenberg_examples_05 = { localeData: %s };', 
+		sprintf(
+			'var gutenberg_examples_05 = { localeData: %s };',
 			json_encode( ! function_exists( 'wp_get_jed_locale_data' ) ? gutenberg_get_jed_locale_data( 'gutenberg-examples' ) : wp_get_jed_locale_data( 'gutenberg-examples' ) )
 		),
 		'before'
 	);
 
-} 
+}
 add_action( 'init', 'gutenberg_examples_05_register_block' );


### PR DESCRIPTION
The .js files should only be loaded in the editor. So we need to change `script` to `editor_script`.
Fixes #53