### PR TITLE
fixing the reference to block.js instead of block.build.js

### DIFF
--- a/01-basic-esnext/index.php
+++ b/01-basic-esnext/index.php
@@ -36,9 +36,9 @@ function gutenberg_examples_01_esnext_register_block() {
 
 	wp_register_script(
 		'gutenberg-examples-01-esnext',
-		plugins_url( 'block.build.js', __FILE__ ),
+		plugins_url( 'block.js', __FILE__ ),
 		array( 'wp-blocks', 'wp-i18n', 'wp-element' ),
-		filemtime( plugin_dir_path( __FILE__ ) . 'block.build.js' )
+		filemtime( plugin_dir_path( __FILE__ ) . 'block.js' )
 	);
 
 	register_block_type( 'gutenberg-examples/example-01-basic-esnext', array(


### PR DESCRIPTION
I couldn't get the "Gutenberg Examples Basic EsNext" to work because the reference to the js file was wrong.