### PR TITLE
Fix attributes type and source in editable block

### DIFF
--- a/03-editable/block.js
+++ b/03-editable/block.js
@@ -16,8 +16,8 @@
 
 		attributes: {
 			content: {
-				type: 'array',
-				source: 'children',
+				type: 'string',
+				source: 'html',
 				selector: 'p',
 			},
 		},


### PR DESCRIPTION
In example of '03-editable/block.js' in GitHub, there is an attribute defined as content and it's type is defined as 'array' and source is defined as 'children' which is wrong as per the Gutenberg handbook(https://wordpress.org/gutenberg/handbook/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields/#attributes) and should be changed with 'string' and 'html'.