### PR TITLE
Align with changes added in Gutenberg docs for Example 1

### DIFF
--- a/01-basic-esnext/src/index.js
+++ b/01-basic-esnext/src/index.js
@@ -12,9 +12,9 @@ registerBlockType( 'gutenberg-examples/example-01-basic-esnext', {
 	icon: 'universal-access-alt',
 	category: 'layout',
 	edit() {
-		return <div style={ blockStyle }>Basic example with JSX! (editor)</div>;
+		return <div style={ blockStyle }>Hello World, step 1 (from the editor).</div>;
 	},
 	save() {
-		return <div style={ blockStyle }>Basic example with JSX! (front)</div>;
+		return <div style={ blockStyle }>Hello World, step 1 (from the frontend).</div>;
 	},
 } );


### PR DESCRIPTION
It follows-up changes added to the block tutorial in Gutenberg added by @truongwp in https://github.com/WordPress/gutenberg/pull/15717.

```diff
diff --git a/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md b/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
index c959b4cd5ae..a4ac0f7a33d 100644
--- a/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
@@ -90,16 +90,16 @@ registerBlockType( 'gutenberg-examples/example-01-basic-esnext', {
 	icon: 'universal-access-alt',
 	category: 'layout',
 	edit() {
-		return <div style={ blockStyle }>Basic example with JSX! (editor)</div>;
+		return <div style={ blockStyle }>Hello World, step 1 (from the editor).</div>;
 	},
 	save() {
-		return <div style={ blockStyle }>Basic example with JSX! (front)</div>;
+		return <div style={ blockStyle }>Hello World, step 1 (from the frontend).</div>;
 	},
 } );
 ```
