### PR TITLE
Try: Add very basic unit tests to validate it works with the repository at the global level

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1105,6 +1105,37 @@
 			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
 			"dev": true
 		},
+		"@tannin/compile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.0.3.tgz",
+			"integrity": "sha512-OkPHvaM/hIHdSco3+ZO1hzkOtfEddn5a0veWft2aDLvKnbdj9VusiLKNdEE9by3hCZIIcb9aWF+iBorhfrQOfw==",
+			"dev": true,
+			"requires": {
+				"@tannin/evaluate": "^1.1.1",
+				"@tannin/postfix": "^1.0.2"
+			}
+		},
+		"@tannin/evaluate": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.1.1.tgz",
+			"integrity": "sha512-ALuSZHjrLHGnw0WxsHDHde74FJ2WW0Ck4rg3QBxFBCmxd6Wsac+e0HXfJ++Qion15LIOCmFhyVpWzawMgeBA8Q==",
+			"dev": true
+		},
+		"@tannin/plural-forms": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.0.3.tgz",
+			"integrity": "sha512-IUr9+FiCnzCiB9aRio3FVNR8TNL9SmX2zkV6tmfWWwSclX4uTCykoGsDhTGKK+sZnMrdPCTmb/OxbtGNdVyV4g==",
+			"dev": true,
+			"requires": {
+				"@tannin/compile": "^1.0.3"
+			}
+		},
+		"@tannin/postfix": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.0.2.tgz",
+			"integrity": "sha512-Nggtk7/ljfNPpAX8CjxxLkMKuO6u2gH1ozmTvGclWF2pNcxTf6YGghYNYNWZRKrimXGhQ8yZqvAHep7h80K04g==",
+			"dev": true
+		},
 		"@types/babel__core": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
@@ -1452,6 +1483,16 @@
 				"long": "^3.2.0"
 			}
 		},
+		"@wordpress/a11y": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.5.0.tgz",
+			"integrity": "sha512-KY+Z0NFQUH6cNbFnP9P58fTCLS93zBz+SIEDA633yG46u1NHOBfWDS4lIrx52fihFdaakSTS0f2OH6yeRb41HQ==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/dom-ready": "^2.5.0"
+			}
+		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-2.3.0.tgz",
@@ -1482,6 +1523,72 @@
 			"integrity": "sha512-vRgzGoxhcNVChBP30XZlyK4w6r/9ZpO+Fi1dzmButp31lUEb1pT5WBxTIQl3HE0JZ9YTEJ00WWGO5sjGi5MHZA==",
 			"dev": true
 		},
+		"@wordpress/components": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.1.0.tgz",
+			"integrity": "sha512-V35ZyDIVadVQQhKB6IyGULdMfi+44KLL6K0FL2gVihLxHq1P0g3sC6kE26DmYNcYXYfhyGMZT440nkUi1jEo3A==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/a11y": "^2.5.0",
+				"@wordpress/compose": "^3.5.0",
+				"@wordpress/dom": "^2.4.0",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/hooks": "^2.5.0",
+				"@wordpress/i18n": "^3.6.0",
+				"@wordpress/is-shallow-equal": "^1.5.0",
+				"@wordpress/keycodes": "^2.5.0",
+				"@wordpress/rich-text": "^3.5.0",
+				"@wordpress/url": "^2.7.0",
+				"classnames": "^2.2.5",
+				"clipboard": "^2.0.1",
+				"diff": "^3.5.0",
+				"dom-scroll-into-view": "^1.2.1",
+				"lodash": "^4.17.14",
+				"memize": "^1.0.5",
+				"moment": "^2.22.1",
+				"mousetrap": "^1.6.2",
+				"re-resizable": "^5.0.1",
+				"react-click-outside": "^3.0.0",
+				"react-dates": "^17.1.1",
+				"react-spring": "^8.0.20",
+				"rememo": "^3.0.0",
+				"tinycolor2": "^1.4.1",
+				"uuid": "^3.3.2"
+			}
+		},
+		"@wordpress/compose": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.5.0.tgz",
+			"integrity": "sha512-X9Qe7gq5+SNvT5yZXSEEgEz5UwUwYh52SBe8WlW59/t182NBBUy9FICEnmx7DRjMugZcSRDwFX39L6tuwo7cnA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/is-shallow-equal": "^1.5.0",
+				"lodash": "^4.17.14"
+			}
+		},
+		"@wordpress/data": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.7.0.tgz",
+			"integrity": "sha512-6ytvrcvg6otalvFNA26gnHv0GQkQT0h9/a780IKl0wyUqAYdKbn1J52CcJWopyfZ53HDq816NCZng1a4tWxHjQ==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/compose": "^3.5.0",
+				"@wordpress/deprecated": "^2.5.0",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/is-shallow-equal": "^1.5.0",
+				"@wordpress/priority-queue": "^1.3.0",
+				"@wordpress/redux-routine": "^3.5.0",
+				"equivalent-key-map": "^0.2.2",
+				"is-promise": "^2.1.0",
+				"lodash": "^4.17.14",
+				"redux": "^4.0.0",
+				"turbo-combine-reducers": "^1.0.2"
+			}
+		},
 		"@wordpress/dependency-extraction-webpack-plugin": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-1.1.0.tgz",
@@ -1490,6 +1597,57 @@
 			"requires": {
 				"webpack": "^4.8.3",
 				"webpack-sources": "^1.3.0"
+			}
+		},
+		"@wordpress/deprecated": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.5.0.tgz",
+			"integrity": "sha512-bryhXZZ9dZ8DlMQ2liDAV3CQV7wEiftJ9UAOB7X32X4MPZoPqvk3IGiKgHFs3/pEr4Ums0CCckgUlnY7AI+hxQ==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/hooks": "^2.5.0"
+			}
+		},
+		"@wordpress/dom": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.4.0.tgz",
+			"integrity": "sha512-8hcHi5iHgi1Z/1G6ti04bgsiYBDNlR05X7MiosjwP8U/iTmcRwKrmtA1X6qzsMlOgvJ3MetoLqGZb3lCjLtXmw==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"lodash": "^4.17.14"
+			}
+		},
+		"@wordpress/dom-ready": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.5.0.tgz",
+			"integrity": "sha512-1CXRTZcQ0yn9Aj5x3e0xwYJeRv81NyuwoQUD2ZvDXRXCvaNq33fm79MDvpW5E2uYoo0t9jPHTCwadVXt7bzhwQ==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4"
+			}
+		},
+		"@wordpress/element": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.6.0.tgz",
+			"integrity": "sha512-t7BgD+gRvC0gOubElsiXhp0H5Dq1yAu2/J8aeok4Fcg1anUXcmjo9M7uL/C17e1AbDVIFQvCyhgOg9ltc/rgEA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/escape-html": "^1.5.0",
+				"lodash": "^4.17.14",
+				"react": "^16.8.4",
+				"react-dom": "^16.8.4"
+			}
+		},
+		"@wordpress/escape-html": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.5.0.tgz",
+			"integrity": "sha512-9jGwPbpdJ309EP4Acf6/zwHWeuYi0Bi5RAZx9q+BIYC7bjxLs3oFDS5QkEAi2mzrVAhIz+BbEWBGRg70U1RLlA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/eslint-plugin": {
@@ -1503,6 +1661,46 @@
 				"eslint-plugin-react": "^7.12.4",
 				"eslint-plugin-react-hooks": "^1.6.0",
 				"requireindex": "^1.2.0"
+			}
+		},
+		"@wordpress/hooks": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.5.0.tgz",
+			"integrity": "sha512-+nsYv5AdX7Oj9gVHvtDIQSE9gntrJwA5FpXSEVlZ2u2E5lhjGQS+a+IrRhxZL/7f2eKby5zvQV6vYCrqMtKxYg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4"
+			}
+		},
+		"@wordpress/i18n": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.0.tgz",
+			"integrity": "sha512-/fkc5OoUCrIyHAaBEKIsXKl+UWj2kKjquhMSSHu3eVqLv/WKrKAzypPPAZC9UXfdSVBY8MrORYLh7vUy9Ic3Vw==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"gettext-parser": "^1.3.1",
+				"lodash": "^4.17.14",
+				"memize": "^1.0.5",
+				"sprintf-js": "^1.1.1",
+				"tannin": "^1.1.0"
+			},
+			"dependencies": {
+				"sprintf-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/is-shallow-equal": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.5.0.tgz",
+			"integrity": "sha512-6GjIDZlwcgLmnt1uexUgnIj3zbzCPCtqe5vTqmsQeexC4zCIzgFJgzilOuuW/4kdwF/XB3jex91L9EImc5HTcw==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/jest-console": {
@@ -1529,11 +1727,64 @@
 				"enzyme-to-json": "^3.3.5"
 			}
 		},
+		"@wordpress/keycodes": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.5.0.tgz",
+			"integrity": "sha512-4SMN3pmJnNBexpd3/6JB6gJw+wcahBaVZaeMcHyF+Uw7bKcG6hDkzEAN6dWFJuifpdxmvilDE4H5JS/Ex9C6sA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/i18n": "^3.6.0",
+				"lodash": "^4.17.14"
+			}
+		},
 		"@wordpress/npm-package-json-lint-config": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-2.1.0.tgz",
 			"integrity": "sha512-NSwcK7GtlmW5O5ZMG7elRKBa9sPws17Sadjlztig6ShOuhlLFeHYk99tUenpmJ/PYOZex4fSJ5e9mqjPyKunjw==",
 			"dev": true
+		},
+		"@wordpress/priority-queue": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.3.0.tgz",
+			"integrity": "sha512-HlhHZUCnKW56b2KFg2cZcn6fnGdi6mrmfOn2lE3cBOibjQLYfOY3pe3TCd+AxS4GdfkgXFA7BHfAinaWCBpAyg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4"
+			}
+		},
+		"@wordpress/redux-routine": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.5.0.tgz",
+			"integrity": "sha512-fssGjVcXlNFbAIjv6VhCWZYgsv51sugxxCgxAqgSIexsDVnOphDODo5V5bhcgwiZeL3/n5rzqvFQ7Dv4agvc/A==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"is-promise": "^2.1.0",
+				"rungen": "^0.3.2"
+			}
+		},
+		"@wordpress/rich-text": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.5.0.tgz",
+			"integrity": "sha512-2Pi56SGcao0M0OjZtpwdIyYIXganIDg054InPpdE7zeJRUxf8gKvTGSXA2bYLdDJC0RgCLTtWp+45ItV6byZDg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/compose": "^3.5.0",
+				"@wordpress/data": "^4.7.0",
+				"@wordpress/deprecated": "^2.5.0",
+				"@wordpress/dom": "^2.4.0",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/escape-html": "^1.5.0",
+				"@wordpress/hooks": "^2.5.0",
+				"@wordpress/is-shallow-equal": "^1.5.0",
+				"@wordpress/keycodes": "^2.5.0",
+				"classnames": "^2.2.5",
+				"lodash": "^4.17.14",
+				"memize": "^1.0.5",
+				"rememo": "^3.0.0"
+			}
 		},
 		"@wordpress/scripts": {
 			"version": "3.4.0",
@@ -1567,6 +1818,16 @@
 				"webpack-bundle-analyzer": "^3.3.2",
 				"webpack-cli": "^3.1.2",
 				"webpack-livereload-plugin": "^2.2.0"
+			}
+		},
+		"@wordpress/url": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.7.0.tgz",
+			"integrity": "sha512-W1KEyllal8YWbLMyqfbPw7pQzVsJh73RQyqElrPwZ84TPeH/1JilKVMgKb2RXgJw8q8I+gZIXi6GmVY0+WNAxg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"qs": "^6.5.2"
 			}
 		},
 		"abab": {
@@ -1840,6 +2101,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
+		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
 			"dev": true
 		},
 		"asn1": {
@@ -2449,6 +2716,12 @@
 				}
 			}
 		},
+		"brcast": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brcast/-/brcast-2.0.2.tgz",
+			"integrity": "sha512-Tfn5JSE7hrUlFcOoaLzVvkbgIemIorMIyoMr3TgvszWW7jFt2C9PdeMLtysYD9RU0MmU17b69+XJG1eRY2OBRg==",
+			"dev": true
+		},
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -2879,6 +3152,12 @@
 				}
 			}
 		},
+		"classnames": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
+			"dev": true
+		},
 		"cli-cursor": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -2893,6 +3172,17 @@
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
 			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
 			"dev": true
+		},
+		"clipboard": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
+			"integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
+			"dev": true,
+			"requires": {
+				"good-listener": "^1.2.2",
+				"select": "^1.1.2",
+				"tiny-emitter": "^2.0.0"
+			}
 		},
 		"cliui": {
 			"version": "4.1.0",
@@ -3035,6 +3325,12 @@
 			"requires": {
 				"date-now": "^0.1.4"
 			}
+		},
+		"consolidated-events": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/consolidated-events/-/consolidated-events-2.0.2.tgz",
+			"integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ==",
+			"dev": true
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -3392,6 +3688,12 @@
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
 			"dev": true
 		},
+		"deepmerge": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
+			"integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==",
+			"dev": true
+		},
 		"define-properties": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -3448,6 +3750,12 @@
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
 		},
+		"delegate": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+			"dev": true
+		},
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -3482,6 +3790,12 @@
 			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
 			"dev": true
 		},
+		"diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"dev": true
+		},
 		"diff-sequences": {
 			"version": "24.3.0",
 			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
@@ -3508,6 +3822,12 @@
 				"path-type": "^3.0.0"
 			}
 		},
+		"direction": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/direction/-/direction-1.0.3.tgz",
+			"integrity": "sha512-8bHRqMt4w/kND19KBksE4NOJo+gIOPuiZfxQvbd6xikfKbuNBYBdLIw0hA/4lWzBaDpwpW+Olmg1BjD9+0LU2w==",
+			"dev": true
+		},
 		"discontinuous-range": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
@@ -3522,6 +3842,21 @@
 			"requires": {
 				"esutils": "^2.0.2"
 			}
+		},
+		"document.contains": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/document.contains/-/document.contains-1.0.1.tgz",
+			"integrity": "sha512-A1KqlZq1w605bwiiLqVZehWE9S9UYlUXPoduFWi64pNVNQ9vy6wwH/7BS+iEfSlF1YyZgcg5PZw5HqDi7FCrUw==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3"
+			}
+		},
+		"dom-scroll-into-view": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.2.1.tgz",
+			"integrity": "sha1-6PNnMt0ImwIBqI14Fdw/iObWbH4=",
+			"dev": true
 		},
 		"dom-serializer": {
 			"version": "0.1.1",
@@ -3661,6 +3996,15 @@
 			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
 			"dev": true
 		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"dev": true,
+			"requires": {
+				"iconv-lite": "~0.4.13"
+			}
+		},
 		"end-of-stream": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -3754,6 +4098,12 @@
 			"requires": {
 				"lodash": "^4.17.12"
 			}
+		},
+		"equivalent-key-map": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.2.tgz",
+			"integrity": "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew==",
+			"dev": true
 		},
 		"errno": {
 			"version": "0.1.7",
@@ -4444,6 +4794,12 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
+		"fast-memoize": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.1.tgz",
+			"integrity": "sha512-xdmw296PCL01tMOXx9mdJSmWY29jQgxyuZdq0rEHMu+Tpe1eOEtCycoG6chzlcrWsNgpZP7oL8RiQr7+G6Bl6g==",
+			"dev": true
+		},
 		"faye-websocket": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
@@ -4460,6 +4816,29 @@
 			"dev": true,
 			"requires": {
 				"bser": "^2.0.0"
+			}
+		},
+		"fbjs": {
+			"version": "0.8.17",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+			"dev": true,
+			"requires": {
+				"core-js": "^1.0.0",
+				"isomorphic-fetch": "^2.1.1",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^0.7.18"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+					"dev": true
+				}
 			}
 		},
 		"fd-slicer": {
@@ -5420,6 +5799,16 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
+		"gettext-parser": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+			"integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+			"dev": true,
+			"requires": {
+				"encoding": "^0.1.12",
+				"safe-buffer": "^5.1.1"
+			}
+		},
 		"glob": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -5460,6 +5849,16 @@
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
 			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
 			"dev": true
+		},
+		"global-cache": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/global-cache/-/global-cache-1.2.1.tgz",
+			"integrity": "sha512-EOeUaup5DgWKlCMhA9YFqNRIlZwoxt731jCh47WBV9fQqHgXhr3Fa55hfgIUqilIcPsfdNKN7LHjrNY+Km40KA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"is-symbol": "^1.0.1"
+			}
 		},
 		"global-modules": {
 			"version": "0.2.3",
@@ -5550,6 +5949,15 @@
 					"integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
 					"dev": true
 				}
+			}
+		},
+		"good-listener": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+			"integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+			"dev": true,
+			"requires": {
+				"delegate": "^3.1.2"
 			}
 		},
 		"graceful-fs": {
@@ -5736,6 +6144,12 @@
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
+		},
+		"hoist-non-react-statics": {
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+			"dev": true
 		},
 		"homedir-polyfill": {
 			"version": "1.0.3",
@@ -6402,6 +6816,12 @@
 				"has-symbols": "^1.0.0"
 			}
 		},
+		"is-touch-device": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-touch-device/-/is-touch-device-1.0.1.tgz",
+			"integrity": "sha512-LAYzo9kMT1b2p19L/1ATGt2XcSilnzNlyvq6c0pbPRVisLbAPpLqr53tIJS00kvrTkj0HtR8U7+u8X0yR8lPSw==",
+			"dev": true
+		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -6455,6 +6875,16 @@
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"dev": true,
+			"requires": {
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
+			}
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -7487,6 +7917,12 @@
 				}
 			}
 		},
+		"memize": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-1.0.5.tgz",
+			"integrity": "sha512-Dm8Jhb5kiC4+ynYsVR4QDXKt+o2dfqGuY4hE2x+XlXZkdndlT80bJxfcMv5QGp/FCy6MhG7f5ElpmKPFKOSEpg==",
+			"dev": true
+		},
 		"memory-fs": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -7759,10 +8195,22 @@
 				}
 			}
 		},
+		"moment": {
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+			"integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+			"dev": true
+		},
 		"moo": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
 			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+			"dev": true
+		},
+		"mousetrap": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.3.tgz",
+			"integrity": "sha512-bd+nzwhhs9ifsUrC2tWaSgm24/oo2c83zaRyZQF06hYA6sANfsXHtnZ19AbbbDXCDzeH5nZBSQ4NvCjgD62tJA==",
 			"dev": true
 		},
 		"move-concurrently": {
@@ -7861,6 +8309,16 @@
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"dev": true,
+			"requires": {
+				"encoding": "^0.1.11",
+				"is-stream": "^1.0.1"
+			}
 		},
 		"node-int64": {
 			"version": "0.4.0",
@@ -8779,6 +9237,15 @@
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
 		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"dev": true,
+			"requires": {
+				"asap": "~2.0.3"
+			}
+		},
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -9005,11 +9472,136 @@
 				"unpipe": "1.0.0"
 			}
 		},
+		"re-resizable": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-5.0.1.tgz",
+			"integrity": "sha512-Iy8v5li7bhNBDxCN1DbA4l6G2Hk8NCZtcExoI1D+5pfvKyQcH8LH2P5h3DGoEfHhs0uyyRC1Qx8bHBomfrmxgA==",
+			"dev": true,
+			"requires": {
+				"fast-memoize": "^2.5.1"
+			}
+		},
+		"react": {
+			"version": "16.9.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
+			"integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2"
+			}
+		},
+		"react-addons-shallow-compare": {
+			"version": "15.6.2",
+			"resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.2.tgz",
+			"integrity": "sha1-GYoAuR/DdiPbZKKP0XtZa6NicC8=",
+			"dev": true,
+			"requires": {
+				"fbjs": "^0.8.4",
+				"object-assign": "^4.1.0"
+			}
+		},
+		"react-click-outside": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-3.0.1.tgz",
+			"integrity": "sha512-d0KWFvBt+esoZUF15rL2UBB7jkeAqLU8L/Ny35oLK6fW6mIbOv/ChD+ExF4sR9PD26kVx+9hNfD0FTIqRZEyRQ==",
+			"dev": true,
+			"requires": {
+				"hoist-non-react-statics": "^2.1.1"
+			}
+		},
+		"react-dates": {
+			"version": "17.2.0",
+			"resolved": "https://registry.npmjs.org/react-dates/-/react-dates-17.2.0.tgz",
+			"integrity": "sha512-RDlerU8DdRRrlYS0MQ7Z9igPWABGLDwz6+ykBNff67RM3Sset2TDqeuOr+R5o00Ggn5U47GeLsGcSDxlZd9cHw==",
+			"dev": true,
+			"requires": {
+				"airbnb-prop-types": "^2.10.0",
+				"consolidated-events": "^1.1.1 || ^2.0.0",
+				"is-touch-device": "^1.0.1",
+				"lodash": "^4.1.1",
+				"object.assign": "^4.1.0",
+				"object.values": "^1.0.4",
+				"prop-types": "^15.6.1",
+				"react-addons-shallow-compare": "^15.6.2",
+				"react-moment-proptypes": "^1.6.0",
+				"react-outside-click-handler": "^1.2.0",
+				"react-portal": "^4.1.5",
+				"react-with-styles": "^3.2.0",
+				"react-with-styles-interface-css": "^4.0.2"
+			}
+		},
+		"react-dom": {
+			"version": "16.9.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
+			"integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2",
+				"scheduler": "^0.15.0"
+			},
+			"dependencies": {
+				"scheduler": {
+					"version": "0.15.0",
+					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
+					"integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
+					"dev": true,
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1"
+					}
+				}
+			}
+		},
 		"react-is": {
 			"version": "16.8.6",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
 			"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
 			"dev": true
+		},
+		"react-moment-proptypes": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.6.0.tgz",
+			"integrity": "sha512-4h7EuhDMTzQqZ+02KUUO+AVA7PqhbD88yXB740nFpNDyDS/bj9jiPyn2rwr9sa8oDyaE1ByFN9+t5XPyPTmN6g==",
+			"dev": true,
+			"requires": {
+				"moment": ">=1.6.0"
+			}
+		},
+		"react-outside-click-handler": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.2.4.tgz",
+			"integrity": "sha512-FwLnTllTa65O/HjIyDgIrlAKcgPeXQnRUE+iR1EV4NY5opzN37S87+AtO1FF0rAa8qBDKj2QuNp4VfkjmkiB7g==",
+			"dev": true,
+			"requires": {
+				"airbnb-prop-types": "^2.13.2",
+				"consolidated-events": "^1.1.1 || ^2.0.0",
+				"document.contains": "^1.0.1",
+				"object.values": "^1.1.0",
+				"prop-types": "^15.7.2"
+			}
+		},
+		"react-portal": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.0.tgz",
+			"integrity": "sha512-Zf+vGQ/VEAb5XAy+muKEn48yhdCNYPZaB1BWg1xc8sAZWD8pXTgPtQT4ihBdmWzsfCq8p8/kqf0GWydSBqc+Eg==",
+			"dev": true,
+			"requires": {
+				"prop-types": "^15.5.8"
+			}
+		},
+		"react-spring": {
+			"version": "8.0.27",
+			"resolved": "https://registry.npmjs.org/react-spring/-/react-spring-8.0.27.tgz",
+			"integrity": "sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"prop-types": "^15.5.8"
+			}
 		},
 		"react-test-renderer": {
 			"version": "16.8.6",
@@ -9021,6 +9613,55 @@
 				"prop-types": "^15.6.2",
 				"react-is": "^16.8.6",
 				"scheduler": "^0.13.6"
+			}
+		},
+		"react-with-direction": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.3.0.tgz",
+			"integrity": "sha512-2TflEebNckTNUybw3Rzqjg4BwM/H380ZL5lsbZ5f4UTY2JyE5uQdQZK5T2w+BDJSAMcqoA2RDJYa4e7Cl6C2Kg==",
+			"dev": true,
+			"requires": {
+				"airbnb-prop-types": "^2.8.1",
+				"brcast": "^2.0.2",
+				"deepmerge": "^1.5.1",
+				"direction": "^1.0.1",
+				"hoist-non-react-statics": "^2.3.1",
+				"object.assign": "^4.1.0",
+				"object.values": "^1.0.4",
+				"prop-types": "^15.6.0"
+			}
+		},
+		"react-with-styles": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-3.2.3.tgz",
+			"integrity": "sha512-MTI1UOvMHABRLj5M4WpODfwnveHaip6X7QUMI2x6zovinJiBXxzhA9AJP7MZNaKqg1JRFtHPXZdroUC8KcXwlQ==",
+			"dev": true,
+			"requires": {
+				"hoist-non-react-statics": "^3.2.1",
+				"object.assign": "^4.1.0",
+				"prop-types": "^15.6.2",
+				"react-with-direction": "^1.3.0"
+			},
+			"dependencies": {
+				"hoist-non-react-statics": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+					"integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+					"dev": true,
+					"requires": {
+						"react-is": "^16.7.0"
+					}
+				}
+			}
+		},
+		"react-with-styles-interface-css": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/react-with-styles-interface-css/-/react-with-styles-interface-css-4.0.3.tgz",
+			"integrity": "sha512-wE43PIyjal2dexxyyx4Lhbcb+E42amoYPnkunRZkb9WTA+Z+9LagbyxwsI352NqMdFmghR0opg29dzDO4/YXbw==",
+			"dev": true,
+			"requires": {
+				"array.prototype.flat": "^1.2.1",
+				"global-cache": "^1.2.1"
 			}
 		},
 		"read-pkg": {
@@ -9167,6 +9808,16 @@
 			"requires": {
 				"indent-string": "^3.0.0",
 				"strip-indent": "^2.0.0"
+			}
+		},
+		"redux": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-4.0.4.tgz",
+			"integrity": "sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"symbol-observable": "^1.2.0"
 			}
 		},
 		"reflect.ownkeys": {
@@ -9319,6 +9970,12 @@
 				"unherit": "^1.0.4",
 				"xtend": "^4.0.1"
 			}
+		},
+		"rememo": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+			"integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ==",
+			"dev": true
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
@@ -9560,6 +10217,12 @@
 				"aproba": "^1.1.1"
 			}
 		},
+		"rungen": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
+			"integrity": "sha1-QAwJ6+kU57F+C27zJjQA/Cq8fLM=",
+			"dev": true
+		},
 		"rx": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
@@ -9644,6 +10307,12 @@
 				"ajv": "^6.1.0",
 				"ajv-keywords": "^3.1.0"
 			}
+		},
+		"select": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+			"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+			"dev": true
 		},
 		"semver": {
 			"version": "5.7.0",
@@ -10512,6 +11181,12 @@
 			"integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
 			"dev": true
 		},
+		"symbol-observable": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+			"dev": true
+		},
 		"symbol-tree": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -10550,6 +11225,15 @@
 						"ansi-regex": "^4.1.0"
 					}
 				}
+			}
+		},
+		"tannin": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.1.0.tgz",
+			"integrity": "sha512-LxhcXqpMHEOVeVKmuG5aCPPsTXFlO373vrWkqN7FSJBVLS6lFOAg8ZGzIyGhrOf7Ho3xB4jdGedY1gi/8J1FCA==",
+			"dev": true,
+			"requires": {
+				"@tannin/plural-forms": "^1.0.3"
 			}
 		},
 		"tapable": {
@@ -10673,6 +11357,12 @@
 				"setimmediate": "^1.0.4"
 			}
 		},
+		"tiny-emitter": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+			"dev": true
+		},
 		"tiny-lr": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
@@ -10697,6 +11387,12 @@
 					}
 				}
 			}
+		},
+		"tinycolor2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
+			"integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
+			"dev": true
 		},
 		"tmp": {
 			"version": "0.0.33",
@@ -10855,6 +11551,12 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"turbo-combine-reducers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/turbo-combine-reducers/-/turbo-combine-reducers-1.0.2.tgz",
+			"integrity": "sha512-gHbdMZlA6Ym6Ur5pSH/UWrNQMIM9IqTH6SoL1DbHpqEdQ8i+cFunSmSlFykPt0eGQwZ4d/XTHOl74H0/kFBVWw==",
+			"dev": true
+		},
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -10884,6 +11586,12 @@
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
+		},
+		"ua-parser-js": {
+			"version": "0.7.20",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
+			"integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==",
 			"dev": true
 		},
 		"uglify-es": {
@@ -11729,6 +12437,12 @@
 			"requires": {
 				"iconv-lite": "0.4.24"
 			}
+		},
+		"whatwg-fetch": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+			"dev": true
 		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
 		"Examples"
 	],
 	"scripts": {
-		"lint-js": "wp-scripts lint-js ./01-basic-esnext ./03-editable-esnext ./04-controls-esnext ./05-recipe-card-esnext",
+		"lint-js": "wp-scripts lint-js ./01-basic-esnext ./03-editable-esnext ./04-controls-esnext ./05-recipe-card-esnext ./test",
 		"lint-js:fix": "npm run lint-js -- --fix",
+		"test": "wp-scripts test-unit-js",
 		"env:start": "docker-compose up -d",
 		"env:stop": "docker-compose stop",
 		"build": "npm run build:01-basic && npm run build:03-editable && npm run build:04-controls && npm run build:05-recipe",
@@ -23,6 +24,7 @@
 		"build:05-recipe": "wp-scripts build 05-recipe-card-esnext/src/index.js --output-path=05-recipe-card-esnext/build"
 	},
 	"devDependencies": {
+		"@wordpress/components": "^8.1.0",
 		"@wordpress/scripts": "^3.4.0"
 	}
 }

--- a/test/__snapshots__/examples.js.snap
+++ b/test/__snapshots__/examples.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders Button from WordPress components 1`] = `
+<button
+  className="components-button"
+  type="button"
+>
+  Click Me!
+</button>
+`;

--- a/test/examples.js
+++ b/test/examples.js
@@ -1,0 +1,28 @@
+/* global test, expect */
+/**
+ * External dependencies
+ */
+import { create as createTestRenderer } from 'react-test-renderer';
+
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+
+// @see https://jestjs.io/docs/en/getting-started
+test( 'adds 1 + 2 to equal 3', () => {
+	function sum( a, b ) {
+		return a + b;
+	}
+
+	expect( sum( 1, 2 ) ).toBe( 3 );
+} );
+
+// @see https://jestjs.io/docs/en/tutorial-react
+test( 'renders Button from WordPress components', () => {
+	const testRenderer = createTestRenderer(
+		<Button>Click Me!</Button>
+	);
+
+	expect( testRenderer.toJSON() ).toMatchSnapshot();
+} );


### PR DESCRIPTION
Initial try to address #26.

This adds very basic unit tests on the repository level. In the long term, we should rather have unit tests for blocks which use ESNext. I think @Shelob9 has some good ideas about what to test which I'm going to explore later. As far as I remember, it's relatively easy to cover `save` implementation with snapshot tests. In case of `edit` implementation, it seems much easier to run e2e tests once we figure out how to set up a local instance of WordPress with the latest Gutenberg and this plugin installed and working with Travis.

## Testing

`npm test`

```bash
local:gutenberg-examples gziolo$ npm run test

> gutenberg-examples@1.0.0 test /Users/gziolo/PhpstormProjects/gutenberg-examples
> wp-scripts test-unit-js

 PASS  test/examples.js
  ✓ adds 1 + 2 to equal 3 (2ms)
  ✓ Button renders (2ms)

 › 1 snapshot written.
Snapshot Summary
 › 1 snapshot written from 1 test suite.

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   1 written, 1 total
Time:        1.58s
Ran all test suites.
```

## Known Issues

When running `npm run lint-js` I see the following errors:

```bash
/Users/gziolo/PhpstormProjects/gutenberg-examples/test/examples.js
  10:1  error  'test' is not defined    no-undef
  11:2  error  'expect' is not defined  no-undef
  14:1  error  'test' is not defined    no-undef
  15:2  error  'expect' is not defined  no-undef

✖ 4 problems (4 errors, 0 warnings)
```

To solve it I had to add:
```diff
+ /* global test, expect */
```

at the top of the file which should work out of the box. This should work out of the box when using `@wordpress/scripts`.

I also had to put:
```diff
+ /**
+  * WordPress dependencies
+  */
import { Button } from '@wordpress/components';
```

above the import statement to fix the following issue:
```bash
 1:1  error  Expected preceding "WordPress dependencies" comment block  @wordpress/dependency-group
```

which I don't think we want to enforce outside of Gutenberg.

/cc @iandunn