### PR TITLE
Chore: Upgrade @wordpress/scripts to the latest version

### DIFF
--- a/01-basic-esnext/build/index.asset.php
+++ b/01-basic-esnext/build/index.asset.php
@@ -1,0 +1,1 @@
+<?php return array('dependencies' => array('wp-element', 'wp-polyfill'), 'version' => 'bc0d337c3714060dec26326dc5e9ad05');

--- a/01-basic-esnext/build/index.deps.json
+++ b/01-basic-esnext/build/index.deps.json
@@ -1,1 +1,0 @@
-["wp-element","wp-polyfill"]

--- a/01-basic-esnext/package.json
+++ b/01-basic-esnext/package.json
@@ -4,7 +4,7 @@
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"devDependencies": {
-		"@wordpress/scripts": "^4.0.0"
+		"@wordpress/scripts": "^5.0.0"
 	},
 	"scripts": {
 		"start": "wp-scripts start",

--- a/01-basic-esnext/package.json
+++ b/01-basic-esnext/package.json
@@ -4,7 +4,7 @@
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"devDependencies": {
-		"@wordpress/scripts": "^3.4.0"
+		"@wordpress/scripts": "^4.0.0"
 	},
 	"scripts": {
 		"start": "wp-scripts start",

--- a/01-basic-esnext/src/index.js
+++ b/01-basic-esnext/src/index.js
@@ -1,4 +1,3 @@
-/* global wp */
 const { __ } = wp.i18n;
 const { registerBlockType } = wp.blocks;
 

--- a/03-editable-esnext/build/index.asset.php
+++ b/03-editable-esnext/build/index.asset.php
@@ -1,0 +1,1 @@
+<?php return array('dependencies' => array('wp-element', 'wp-polyfill'), 'version' => 'eab824cf46695adc6fd8fa6d4cd1a364');

--- a/03-editable-esnext/build/index.deps.json
+++ b/03-editable-esnext/build/index.deps.json
@@ -1,1 +1,0 @@
-["wp-element","wp-polyfill"]

--- a/03-editable-esnext/package.json
+++ b/03-editable-esnext/package.json
@@ -4,7 +4,7 @@
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"devDependencies": {
-		"@wordpress/scripts": "^4.0.0"
+		"@wordpress/scripts": "^5.0.0"
 	},
 	"scripts": {
 		"start": "wp-scripts start",

--- a/03-editable-esnext/package.json
+++ b/03-editable-esnext/package.json
@@ -4,7 +4,7 @@
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"devDependencies": {
-		"@wordpress/scripts": "^3.4.0"
+		"@wordpress/scripts": "^4.0.0"
 	},
 	"scripts": {
 		"start": "wp-scripts start",

--- a/03-editable-esnext/src/index.js
+++ b/03-editable-esnext/src/index.js
@@ -1,4 +1,3 @@
-/* global wp */
 const { __ } = wp.i18n;
 const { registerBlockType } = wp.blocks;
 const { RichText } = wp.editor;

--- a/04-controls-esnext/build/index.asset.php
+++ b/04-controls-esnext/build/index.asset.php
@@ -1,0 +1,1 @@
+<?php return array('dependencies' => array('wp-element', 'wp-polyfill'), 'version' => 'ce5450bf3cd72d7101c8f1209c2b6c9b');

--- a/04-controls-esnext/build/index.deps.json
+++ b/04-controls-esnext/build/index.deps.json
@@ -1,1 +1,0 @@
-["wp-element","wp-polyfill"]

--- a/04-controls-esnext/package.json
+++ b/04-controls-esnext/package.json
@@ -4,7 +4,7 @@
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"devDependencies": {
-		"@wordpress/scripts": "^4.0.0"
+		"@wordpress/scripts": "^5.0.0"
 	},
 	"scripts": {
 		"start": "wp-scripts start",

--- a/04-controls-esnext/package.json
+++ b/04-controls-esnext/package.json
@@ -4,7 +4,7 @@
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"devDependencies": {
-		"@wordpress/scripts": "^3.4.0"
+		"@wordpress/scripts": "^4.0.0"
 	},
 	"scripts": {
 		"start": "wp-scripts start",

--- a/04-controls-esnext/src/index.js
+++ b/04-controls-esnext/src/index.js
@@ -1,4 +1,3 @@
-/* global wp */
 const { __ } = wp.i18n;
 const {
 	registerBlockType,

--- a/05-recipe-card-esnext/build/index.asset.php
+++ b/05-recipe-card-esnext/build/index.asset.php
@@ -1,0 +1,1 @@
+<?php return array('dependencies' => array('wp-element', 'wp-polyfill'), 'version' => 'a60f5a048970eae32a261c8ac4754158');

--- a/05-recipe-card-esnext/build/index.deps.json
+++ b/05-recipe-card-esnext/build/index.deps.json
@@ -1,1 +1,0 @@
-["wp-element","wp-polyfill"]

--- a/05-recipe-card-esnext/package.json
+++ b/05-recipe-card-esnext/package.json
@@ -4,7 +4,7 @@
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"devDependencies": {
-		"@wordpress/scripts": "^4.0.0"
+		"@wordpress/scripts": "^5.0.0"
 	},
 	"scripts": {
 		"start": "wp-scripts start",

--- a/05-recipe-card-esnext/package.json
+++ b/05-recipe-card-esnext/package.json
@@ -4,7 +4,7 @@
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"devDependencies": {
-		"@wordpress/scripts": "^3.4.0"
+		"@wordpress/scripts": "^4.0.0"
 	},
 	"scripts": {
 		"start": "wp-scripts start",

--- a/05-recipe-card-esnext/src/index.js
+++ b/05-recipe-card-esnext/src/index.js
@@ -1,4 +1,3 @@
-/* global wp */
 const { __ } = wp.i18n;
 const {
 	registerBlockType,

--- a/package-lock.json
+++ b/package-lock.json
@@ -847,137 +847,119 @@
 			"integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==",
 			"dev": true
 		},
+		"@hapi/bourne": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+			"integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+			"dev": true
+		},
 		"@hapi/hoek": {
-			"version": "6.2.4",
-			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
-			"integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.1.tgz",
+			"integrity": "sha512-JPiBy+oSmsq3St7XlipfN5pNA6bDJ1kpa73PrK/zR29CVClDVqy04AanM/M/qx5bSF+I61DdCfAvRrujau+zRg==",
 			"dev": true
 		},
 		"@hapi/joi": {
-			"version": "15.1.0",
-			"resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.0.tgz",
-			"integrity": "sha512-n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==",
+			"version": "15.1.1",
+			"resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+			"integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
 			"dev": true,
 			"requires": {
 				"@hapi/address": "2.x.x",
-				"@hapi/hoek": "6.x.x",
-				"@hapi/marker": "1.x.x",
+				"@hapi/bourne": "1.x.x",
+				"@hapi/hoek": "8.x.x",
 				"@hapi/topo": "3.x.x"
 			}
 		},
-		"@hapi/marker": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/marker/-/marker-1.0.0.tgz",
-			"integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA==",
-			"dev": true
-		},
 		"@hapi/topo": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.2.tgz",
-			"integrity": "sha512-r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.3.tgz",
+			"integrity": "sha512-JmS9/vQK6dcUYn7wc2YZTqzIKubAQcJKu2KCKAru6es482U5RT5fP1EXCPtlXpiK7PR0On/kpQKI4fRKkzpZBQ==",
 			"dev": true,
 			"requires": {
 				"@hapi/hoek": "8.x.x"
-			},
-			"dependencies": {
-				"@hapi/hoek": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.1.0.tgz",
-					"integrity": "sha512-b1J4jxYnW+n6lC91V6Pqg9imP9BZq0HNCeM+3sbXg05rQsE9cGYrKFpZjyztVesGmNRE6R+QaEoWGATeIiUVjA==",
-					"dev": true
-				}
 			}
 		},
 		"@jest/console": {
-			"version": "24.7.1",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
-			"integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
+			"integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
 			"dev": true,
 			"requires": {
-				"@jest/source-map": "^24.3.0",
+				"@jest/source-map": "^24.9.0",
 				"chalk": "^2.0.1",
 				"slash": "^2.0.0"
 			}
 		},
 		"@jest/core": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.8.0.tgz",
-			"integrity": "sha512-R9rhAJwCBQzaRnrRgAdVfnglUuATXdwTRsYqs6NMdVcAl5euG8LtWDe+fVkN27YfKVBW61IojVsXKaOmSnqd/A==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
+			"integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
 			"dev": true,
 			"requires": {
 				"@jest/console": "^24.7.1",
-				"@jest/reporters": "^24.8.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/reporters": "^24.9.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/transform": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.1",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.1.15",
-				"jest-changed-files": "^24.8.0",
-				"jest-config": "^24.8.0",
-				"jest-haste-map": "^24.8.0",
-				"jest-message-util": "^24.8.0",
+				"jest-changed-files": "^24.9.0",
+				"jest-config": "^24.9.0",
+				"jest-haste-map": "^24.9.0",
+				"jest-message-util": "^24.9.0",
 				"jest-regex-util": "^24.3.0",
-				"jest-resolve-dependencies": "^24.8.0",
-				"jest-runner": "^24.8.0",
-				"jest-runtime": "^24.8.0",
-				"jest-snapshot": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"jest-validate": "^24.8.0",
-				"jest-watcher": "^24.8.0",
+				"jest-resolve": "^24.9.0",
+				"jest-resolve-dependencies": "^24.9.0",
+				"jest-runner": "^24.9.0",
+				"jest-runtime": "^24.9.0",
+				"jest-snapshot": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"jest-validate": "^24.9.0",
+				"jest-watcher": "^24.9.0",
 				"micromatch": "^3.1.10",
 				"p-each-series": "^1.0.0",
-				"pirates": "^4.0.1",
 				"realpath-native": "^1.1.0",
 				"rimraf": "^2.5.4",
+				"slash": "^2.0.0",
 				"strip-ansi": "^5.0.0"
-			},
-			"dependencies": {
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
 			}
 		},
 		"@jest/environment": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.8.0.tgz",
-			"integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
+			"integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "^24.8.0",
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"jest-mock": "^24.8.0"
+				"@jest/fake-timers": "^24.9.0",
+				"@jest/transform": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"jest-mock": "^24.9.0"
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.8.0.tgz",
-			"integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
+			"integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-mock": "^24.8.0"
+				"@jest/types": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-mock": "^24.9.0"
 			}
 		},
 		"@jest/reporters": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.8.0.tgz",
-			"integrity": "sha512-eZ9TyUYpyIIXfYCrw0UHUWUvE35vx5I92HGMgS93Pv7du+GHIzl+/vh8Qj9MCWFK/4TqyttVBPakWMOfZRIfxw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
+			"integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.8.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/environment": "^24.9.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/transform": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"chalk": "^2.0.1",
 				"exit": "^0.1.2",
 				"glob": "^7.1.2",
@@ -985,13 +967,13 @@
 				"istanbul-lib-instrument": "^3.0.1",
 				"istanbul-lib-report": "^2.0.4",
 				"istanbul-lib-source-maps": "^3.0.1",
-				"istanbul-reports": "^2.1.1",
-				"jest-haste-map": "^24.8.0",
-				"jest-resolve": "^24.8.0",
-				"jest-runtime": "^24.8.0",
-				"jest-util": "^24.8.0",
+				"istanbul-reports": "^2.2.6",
+				"jest-haste-map": "^24.9.0",
+				"jest-resolve": "^24.9.0",
+				"jest-runtime": "^24.9.0",
+				"jest-util": "^24.9.0",
 				"jest-worker": "^24.6.0",
-				"node-notifier": "^5.2.1",
+				"node-notifier": "^5.4.2",
 				"slash": "^2.0.0",
 				"source-map": "^0.6.0",
 				"string-length": "^2.0.0"
@@ -1006,9 +988,9 @@
 			}
 		},
 		"@jest/source-map": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
-			"integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
+			"integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0",
@@ -1025,45 +1007,46 @@
 			}
 		},
 		"@jest/test-result": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.8.0.tgz",
-			"integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
+			"integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/types": "^24.8.0",
+				"@jest/console": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"@types/istanbul-lib-coverage": "^2.0.0"
 			}
 		},
 		"@jest/test-sequencer": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.8.0.tgz",
-			"integrity": "sha512-OzL/2yHyPdCHXEzhoBuq37CE99nkme15eHkAzXRVqthreWZamEMA0WoetwstsQBCXABhczpK03JNbc4L01vvLg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
+			"integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^24.8.0",
-				"jest-haste-map": "^24.8.0",
-				"jest-runner": "^24.8.0",
-				"jest-runtime": "^24.8.0"
+				"@jest/test-result": "^24.9.0",
+				"jest-haste-map": "^24.9.0",
+				"jest-runner": "^24.9.0",
+				"jest-runtime": "^24.9.0"
 			}
 		},
 		"@jest/transform": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.8.0.tgz",
-			"integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.9.0.tgz",
+			"integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"babel-plugin-istanbul": "^5.1.0",
 				"chalk": "^2.0.1",
 				"convert-source-map": "^1.4.0",
 				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.1.15",
-				"jest-haste-map": "^24.8.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-util": "^24.8.0",
+				"jest-haste-map": "^24.9.0",
+				"jest-regex-util": "^24.9.0",
+				"jest-util": "^24.9.0",
 				"micromatch": "^3.1.10",
+				"pirates": "^4.0.1",
 				"realpath-native": "^1.1.0",
 				"slash": "^2.0.0",
 				"source-map": "^0.6.1",
@@ -1079,14 +1062,14 @@
 			}
 		},
 		"@jest/types": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
-			"integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+			"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
 			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"@types/istanbul-reports": "^1.1.1",
-				"@types/yargs": "^12.0.9"
+				"@types/yargs": "^13.0.0"
 			}
 		},
 		"@mrmlnc/readdir-enhanced": {
@@ -1219,6 +1202,12 @@
 				"@types/istanbul-lib-report": "*"
 			}
 		},
+		"@types/json-schema": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
+			"integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+			"dev": true
+		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -1226,9 +1215,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "12.6.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-			"integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw==",
+			"version": "12.7.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz",
+			"integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==",
 			"dev": true
 		},
 		"@types/stack-utils": {
@@ -1265,10 +1254,60 @@
 			}
 		},
 		"@types/yargs": {
-			"version": "12.0.12",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.12.tgz",
-			"integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==",
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.2.tgz",
+			"integrity": "sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==",
+			"dev": true,
+			"requires": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"@types/yargs-parser": {
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.0.0.tgz",
+			"integrity": "sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==",
 			"dev": true
+		},
+		"@typescript-eslint/experimental-utils": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+			"integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+			"dev": true,
+			"requires": {
+				"@types/json-schema": "^7.0.3",
+				"@typescript-eslint/typescript-estree": "1.13.0",
+				"eslint-scope": "^4.0.0"
+			},
+			"dependencies": {
+				"eslint-scope": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
+				}
+			}
+		},
+		"@typescript-eslint/typescript-estree": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
+			"integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+			"dev": true,
+			"requires": {
+				"lodash.unescape": "4.0.1",
+				"semver": "5.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+					"dev": true
+				}
+			}
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.4.3",
@@ -1500,9 +1539,9 @@
 			"dev": true
 		},
 		"@wordpress/babel-preset-default": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.4.0.tgz",
-			"integrity": "sha512-cFdzlVSYe7M4lKojBxG/TaoRAL6r/UZhvFN7R7e49qlrNlB20YTGSkpKffO1h158mlPuunFIIt+425w/xQE8/g==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.5.0.tgz",
+			"integrity": "sha512-LkRtmVAsFP/litK323Y6Yk1/3GujyhBykToG3iCPbRoA4elGybCaj9AqXgSS1gIxxRYOTFf8Gt0LaF+xShIGuQ==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.4.4",
@@ -1514,7 +1553,16 @@
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/babel-plugin-import-jsx-pragma": "^2.3.0",
 				"@wordpress/browserslist-config": "^2.6.0",
+				"@wordpress/element": "^2.7.0",
 				"core-js": "^3.1.4"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/browserslist-config": {
@@ -1524,32 +1572,30 @@
 			"dev": true
 		},
 		"@wordpress/components": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.1.0.tgz",
-			"integrity": "sha512-V35ZyDIVadVQQhKB6IyGULdMfi+44KLL6K0FL2gVihLxHq1P0g3sC6kE26DmYNcYXYfhyGMZT440nkUi1jEo3A==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.2.0.tgz",
+			"integrity": "sha512-fde8bKDNcn9fhq48Mj2QyaTjrluYBK8A77P+MGmiU/x72FtMvj8/HdBOoDpmuGMApTc5oDAfAzNiYyDHIHzNqQ==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/a11y": "^2.5.0",
-				"@wordpress/compose": "^3.5.0",
-				"@wordpress/dom": "^2.4.0",
-				"@wordpress/element": "^2.6.0",
-				"@wordpress/hooks": "^2.5.0",
+				"@wordpress/compose": "^3.6.0",
+				"@wordpress/deprecated": "^2.6.0",
+				"@wordpress/dom": "^2.5.0",
+				"@wordpress/element": "^2.7.0",
+				"@wordpress/hooks": "^2.6.0",
 				"@wordpress/i18n": "^3.6.0",
-				"@wordpress/is-shallow-equal": "^1.5.0",
-				"@wordpress/keycodes": "^2.5.0",
-				"@wordpress/rich-text": "^3.5.0",
-				"@wordpress/url": "^2.7.0",
+				"@wordpress/is-shallow-equal": "^1.6.0",
+				"@wordpress/keycodes": "^2.6.0",
+				"@wordpress/rich-text": "^3.6.0",
 				"classnames": "^2.2.5",
 				"clipboard": "^2.0.1",
-				"diff": "^3.5.0",
 				"dom-scroll-into-view": "^1.2.1",
 				"lodash": "^4.17.14",
 				"memize": "^1.0.5",
 				"moment": "^2.22.1",
 				"mousetrap": "^1.6.2",
-				"re-resizable": "^5.0.1",
-				"react-click-outside": "^3.0.0",
+				"re-resizable": "^6.0.0",
 				"react-dates": "^17.1.1",
 				"react-spring": "^8.0.20",
 				"rememo": "^3.0.0",
@@ -1558,30 +1604,30 @@
 			}
 		},
 		"@wordpress/compose": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.5.0.tgz",
-			"integrity": "sha512-X9Qe7gq5+SNvT5yZXSEEgEz5UwUwYh52SBe8WlW59/t182NBBUy9FICEnmx7DRjMugZcSRDwFX39L6tuwo7cnA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.6.0.tgz",
+			"integrity": "sha512-ixXGsj2aBizA4XiawR0n8+Ee2vmhmyGkd9Cy4LZs4aQFunDVXuVypxk74YQJstzJCUVMdvR8B5K8vrnh38QDFw==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/element": "^2.6.0",
-				"@wordpress/is-shallow-equal": "^1.5.0",
+				"@wordpress/element": "^2.7.0",
+				"@wordpress/is-shallow-equal": "^1.6.0",
 				"lodash": "^4.17.14"
 			}
 		},
 		"@wordpress/data": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.7.0.tgz",
-			"integrity": "sha512-6ytvrcvg6otalvFNA26gnHv0GQkQT0h9/a780IKl0wyUqAYdKbn1J52CcJWopyfZ53HDq816NCZng1a4tWxHjQ==",
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.8.0.tgz",
+			"integrity": "sha512-WUdE6C7CfG6gcQw2nZ+VQ3EAB5alga97BjqTdvuAAm6BLFLwd5LDn4maQYLPFrQp27CyzjDy6KzKARHDrUJBOg==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/compose": "^3.5.0",
-				"@wordpress/deprecated": "^2.5.0",
-				"@wordpress/element": "^2.6.0",
-				"@wordpress/is-shallow-equal": "^1.5.0",
+				"@wordpress/compose": "^3.6.0",
+				"@wordpress/deprecated": "^2.6.0",
+				"@wordpress/element": "^2.7.0",
+				"@wordpress/is-shallow-equal": "^1.6.0",
 				"@wordpress/priority-queue": "^1.3.0",
-				"@wordpress/redux-routine": "^3.5.0",
+				"@wordpress/redux-routine": "^3.6.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-promise": "^2.1.0",
 				"lodash": "^4.17.14",
@@ -1590,9 +1636,9 @@
 			}
 		},
 		"@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-1.1.0.tgz",
-			"integrity": "sha512-tCyxy7hLzDdCHQ1xGPiMlE7fBp/pCuEum89gqzoiz2HQJld6F7BTNMo3XfTzxFO0SHh/C64yOZgBB8FvH+warQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-1.2.0.tgz",
+			"integrity": "sha512-+x0ID9r1cyXMCAoN8leM0Eo5IJ/iFW4+4y323dLcksP6PBoY78f8sJeSwTH058Ts9en7wvsRc8pdOza/gZHVpw==",
 			"dev": true,
 			"requires": {
 				"webpack": "^4.8.3",
@@ -1600,19 +1646,19 @@
 			}
 		},
 		"@wordpress/deprecated": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.5.0.tgz",
-			"integrity": "sha512-bryhXZZ9dZ8DlMQ2liDAV3CQV7wEiftJ9UAOB7X32X4MPZoPqvk3IGiKgHFs3/pEr4Ums0CCckgUlnY7AI+hxQ==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.6.0.tgz",
+			"integrity": "sha512-DLYEhsG04V8qfm+k2hrHPExiC31+dgUGZBhIUq8ScvCIkqYOiWAgP0zTOjRgSuNk8Yp0/6XqSWbkXMC4ZQX03w==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/hooks": "^2.5.0"
+				"@wordpress/hooks": "^2.6.0"
 			}
 		},
 		"@wordpress/dom": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.4.0.tgz",
-			"integrity": "sha512-8hcHi5iHgi1Z/1G6ti04bgsiYBDNlR05X7MiosjwP8U/iTmcRwKrmtA1X6qzsMlOgvJ3MetoLqGZb3lCjLtXmw==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.5.0.tgz",
+			"integrity": "sha512-nJUskVX/0RIskGgQBCXRrMMMxJcZ1UwQlpDBMNVPwMD9KPw13YnzCTzR6QgUMvCYF4pDUmxVIP+ao7CQzAL9lg==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
@@ -1629,9 +1675,9 @@
 			}
 		},
 		"@wordpress/element": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.6.0.tgz",
-			"integrity": "sha512-t7BgD+gRvC0gOubElsiXhp0H5Dq1yAu2/J8aeok4Fcg1anUXcmjo9M7uL/C17e1AbDVIFQvCyhgOg9ltc/rgEA==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.7.0.tgz",
+			"integrity": "sha512-wyGOSFucslwndsSU4VlO7Z67C4NszsESM21fDwLF3z/JUcZDbcTZLmEId2QysgYUYtX5sBk6OvoTe8f4FY+SKQ==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
@@ -1651,22 +1697,36 @@
 			}
 		},
 		"@wordpress/eslint-plugin": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-2.4.0.tgz",
-			"integrity": "sha512-FOsNM6cCKZKug/sXKAum1lceGiULm4sKZlBCHUHRNiGSbOlWs+kjoATQOuid9nGYVK/uzvQOCN1xwZJbQ9XjDw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-3.0.0.tgz",
+			"integrity": "sha512-/X3hDwIgtPLp4niG+1S+QqKSgYBhYNjyZUB6W2k8ytsd0Z+WAKDN4hIbJ8/UY8XNVs+marhlJpgxfhlVLP/4ig==",
 			"dev": true,
 			"requires": {
-				"babel-eslint": "^10.0.1",
-				"eslint-plugin-jsx-a11y": "^6.2.1",
-				"eslint-plugin-react": "^7.12.4",
-				"eslint-plugin-react-hooks": "^1.6.0",
+				"babel-eslint": "^10.0.2",
+				"eslint-plugin-jest": "^22.15.1",
+				"eslint-plugin-jsdoc": "^15.8.0",
+				"eslint-plugin-jsx-a11y": "^6.2.3",
+				"eslint-plugin-react": "^7.14.3",
+				"eslint-plugin-react-hooks": "^1.6.1",
+				"globals": "^12.0.0",
 				"requireindex": "^1.2.0"
+			},
+			"dependencies": {
+				"globals": {
+					"version": "12.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-12.0.0.tgz",
+					"integrity": "sha512-c9xoi32iDwlETiyYfO0pd3M8GcEuytJinSoqq7k3fz4H8p2p31NyfKr7JVd7Y0QvmtWcWXcwqW4L33eeDYgh1A==",
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.6.0"
+					}
+				}
 			}
 		},
 		"@wordpress/hooks": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.5.0.tgz",
-			"integrity": "sha512-+nsYv5AdX7Oj9gVHvtDIQSE9gntrJwA5FpXSEVlZ2u2E5lhjGQS+a+IrRhxZL/7f2eKby5zvQV6vYCrqMtKxYg==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.6.0.tgz",
+			"integrity": "sha512-93THIW9EklVkJLN3wr8PUdWqttRu/wGZgXUrM6fqqOGwm4uCL4S+jQe800kwZioRHvgW5moNLrvSdfanQ4QyEQ==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4"
@@ -1684,29 +1744,21 @@
 				"memize": "^1.0.5",
 				"sprintf-js": "^1.1.1",
 				"tannin": "^1.1.0"
-			},
-			"dependencies": {
-				"sprintf-js": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/is-shallow-equal": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.5.0.tgz",
-			"integrity": "sha512-6GjIDZlwcgLmnt1uexUgnIj3zbzCPCtqe5vTqmsQeexC4zCIzgFJgzilOuuW/4kdwF/XB3jex91L9EImc5HTcw==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.6.0.tgz",
+			"integrity": "sha512-Yi3JvowB1+bpiKnx9OYv5Ni2zA/j8zJa5dTA5IuchOgdODRGlg9XAuC1Kl0Bd9nLmQsoU50TJYiAlffv0lUhzQ==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/jest-console": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-3.2.0.tgz",
-			"integrity": "sha512-WZl2eJH9g+OSTrFPpAKSCT7Pl7rvwatPnBm1Z4kpPZdOQDbF3w2a6yzfpjtBBD2BVEqHsaLAxn0jC6xHkqbAxw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-3.3.0.tgz",
+			"integrity": "sha512-ga6KMvj81IclhT/3z7GYQZPdVYhBbasjYbCuzMwyFLMDGu3AZJVsxhTFufr2co3cSi03Z8dhWL2Mm9IEzQujdA==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
@@ -1715,12 +1767,12 @@
 			}
 		},
 		"@wordpress/jest-preset-default": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-4.3.0.tgz",
-			"integrity": "sha512-b8rucE3e7+VkD/gX9pB6c9ZysjUAOfNG2Lcp8OLtfzWvlzMkuJtl7+9P/D6GAWk2GEK54GdM018vl3IM5HkaHg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-5.0.0.tgz",
+			"integrity": "sha512-+I84XwTC+aRq2W6R6XeCCK7DFVUrNq/WzyzmhsFvfE4Kbb3+LJzhMUhpzNLTtZztZaBbDN/374xpeyEEZTNClw==",
 			"dev": true,
 			"requires": {
-				"@wordpress/jest-console": "^3.2.0",
+				"@wordpress/jest-console": "^3.3.0",
 				"babel-jest": "^24.7.1",
 				"enzyme": "^3.9.0",
 				"enzyme-adapter-react-16": "^1.10.0",
@@ -1728,9 +1780,9 @@
 			}
 		},
 		"@wordpress/keycodes": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.5.0.tgz",
-			"integrity": "sha512-4SMN3pmJnNBexpd3/6JB6gJw+wcahBaVZaeMcHyF+Uw7bKcG6hDkzEAN6dWFJuifpdxmvilDE4H5JS/Ex9C6sA==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.6.0.tgz",
+			"integrity": "sha512-wWCyom/dHMBb2hmNbuZym30/6QrvW2RvIbQNu1LHNZvVqehMOQLdVMUf525aLVJVQfp9wfer/fz5TjphW43txA==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
@@ -1754,32 +1806,31 @@
 			}
 		},
 		"@wordpress/redux-routine": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.5.0.tgz",
-			"integrity": "sha512-fssGjVcXlNFbAIjv6VhCWZYgsv51sugxxCgxAqgSIexsDVnOphDODo5V5bhcgwiZeL3/n5rzqvFQ7Dv4agvc/A==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.6.0.tgz",
+			"integrity": "sha512-uZE6vA3XISS42aR2lx/5dUSPDXYLo1ETFPNzW1JN19NbwwpF/n2S1uUxICskNHe/Ku/bB8tZ+QRrd7AquyqhQQ==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"is-promise": "^2.1.0",
+				"lodash": "^4.17.14",
 				"rungen": "^0.3.2"
 			}
 		},
 		"@wordpress/rich-text": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.5.0.tgz",
-			"integrity": "sha512-2Pi56SGcao0M0OjZtpwdIyYIXganIDg054InPpdE7zeJRUxf8gKvTGSXA2bYLdDJC0RgCLTtWp+45ItV6byZDg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.6.0.tgz",
+			"integrity": "sha512-DbiCo1Cypkz9EJ38eGvoNpM/tDTRZYrCNYSDRhNHAK6zODUqTB9L6+tGVdpUQSTjsgoFUBoVeqAAM3hIvcTjgQ==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/compose": "^3.5.0",
-				"@wordpress/data": "^4.7.0",
-				"@wordpress/deprecated": "^2.5.0",
-				"@wordpress/dom": "^2.4.0",
-				"@wordpress/element": "^2.6.0",
+				"@wordpress/compose": "^3.6.0",
+				"@wordpress/data": "^4.8.0",
+				"@wordpress/element": "^2.7.0",
 				"@wordpress/escape-html": "^1.5.0",
-				"@wordpress/hooks": "^2.5.0",
-				"@wordpress/is-shallow-equal": "^1.5.0",
-				"@wordpress/keycodes": "^2.5.0",
+				"@wordpress/hooks": "^2.6.0",
+				"@wordpress/is-shallow-equal": "^1.6.0",
+				"@wordpress/keycodes": "^2.6.0",
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.14",
 				"memize": "^1.0.5",
@@ -1787,27 +1838,27 @@
 			}
 		},
 		"@wordpress/scripts": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-3.4.0.tgz",
-			"integrity": "sha512-PPOXYLLnqdxc/w0BU7YpJoa2G14WbukeWZGavjiYl98l5x4QO6Ddpo31D8Ev+kBMkmIWeyO7Pmgj0flrg8Vd/w==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-4.0.0.tgz",
+			"integrity": "sha512-OS0gIL2lfEcegZq6sl7kaZUhViYYhA/Ulb1BR53w31az/n/FdcHJi/EfxFXMWIsVE9CmEgU3r8bTXB6vwjnedg==",
 			"dev": true,
 			"requires": {
-				"@wordpress/babel-preset-default": "^4.4.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^1.1.0",
-				"@wordpress/eslint-plugin": "^2.4.0",
-				"@wordpress/jest-preset-default": "^4.3.0",
+				"@wordpress/babel-preset-default": "^4.5.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^1.2.0",
+				"@wordpress/eslint-plugin": "^3.0.0",
+				"@wordpress/jest-preset-default": "^5.0.0",
 				"@wordpress/npm-package-json-lint-config": "^2.1.0",
 				"babel-jest": "^24.7.1",
 				"babel-loader": "^8.0.5",
 				"chalk": "^2.4.1",
 				"check-node-version": "^3.1.1",
 				"cross-spawn": "^5.1.0",
-				"eslint": "^5.16.0",
+				"eslint": "^6.1.0",
 				"jest": "^24.7.1",
-				"jest-puppeteer": "^4.0.0",
+				"jest-puppeteer": "^4.3.0",
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^3.6.0",
-				"puppeteer": "1.6.1",
+				"puppeteer": "^1.19.0",
 				"read-pkg-up": "^1.0.1",
 				"resolve-bin": "^0.4.0",
 				"source-map-loader": "^0.2.4",
@@ -1820,20 +1871,10 @@
 				"webpack-livereload-plugin": "^2.2.0"
 			}
 		},
-		"@wordpress/url": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.7.0.tgz",
-			"integrity": "sha512-W1KEyllal8YWbLMyqfbPw7pQzVsJh73RQyqElrPwZ84TPeH/1JilKVMgKb2RXgJw8q8I+gZIXi6GmVY0+WNAxg==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.4.4",
-				"qs": "^6.5.2"
-			}
-		},
 		"abab": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
-			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.1.tgz",
+			"integrity": "sha512-1zSbbCuoIjafKZ3mblY5ikvAb0ODUbqBnFuUb7f6uLeQhhGJ0vEV4ntmtxKLT2WgXCO94E07BjunsIw1jOMPZw==",
 			"dev": true
 		},
 		"accepts": {
@@ -1872,17 +1913,17 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-					"integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+					"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
 					"dev": true
 				}
 			}
 		},
 		"acorn-jsx": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-			"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
+			"integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
 			"dev": true
 		},
 		"acorn-walk": {
@@ -1901,9 +1942,9 @@
 			}
 		},
 		"airbnb-prop-types": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.14.0.tgz",
-			"integrity": "sha512-Yb09vUkr3KP9r9NqfRuYtDYZG76wt8mhTUi2Vfzsghk+qkg01/gOc9NU8n63ZcMCLzpAdMEXyKjCHlxV62yN1A==",
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.15.0.tgz",
+			"integrity": "sha512-jUh2/hfKsRjNFC4XONQrxo/n/3GG4Tn6Hl0WlFQN5PY9OMC9loSCoAYKnZsWaP8wEfd5xcrPloK0Zg6iS1xwVA==",
 			"dev": true,
 			"requires": {
 				"array.prototype.find": "^2.1.0",
@@ -1915,7 +1956,7 @@
 				"object.entries": "^1.1.0",
 				"prop-types": "^15.7.2",
 				"prop-types-exact": "^1.2.0",
-				"react-is": "^16.8.6"
+				"react-is": "^16.9.0"
 			}
 		},
 		"ajv": {
@@ -1991,6 +2032,14 @@
 			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
+			},
+			"dependencies": {
+				"sprintf-js": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+					"dev": true
+				}
 			}
 		},
 		"aria-query": {
@@ -2229,9 +2278,9 @@
 			},
 			"dependencies": {
 				"postcss-value-parser": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.0.tgz",
-					"integrity": "sha512-ESPktioptiSUchCKgggAkzdmkgzKfmp0EU8jXH+5kbIUB+unr0Y4CY9SRMvibuvYUBjNh1ACLbxqYNpdTQOteQ==",
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+					"integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
 					"dev": true
 				}
 			}
@@ -2258,42 +2307,30 @@
 			}
 		},
 		"babel-eslint": {
-			"version": "10.0.2",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.2.tgz",
-			"integrity": "sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==",
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
+			"integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@babel/parser": "^7.0.0",
 				"@babel/traverse": "^7.0.0",
 				"@babel/types": "^7.0.0",
-				"eslint-scope": "3.7.1",
-				"eslint-visitor-keys": "^1.0.0"
-			},
-			"dependencies": {
-				"eslint-scope": {
-					"version": "3.7.1",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-					"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-					"dev": true,
-					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
-					}
-				}
+				"eslint-visitor-keys": "^1.0.0",
+				"resolve": "^1.12.0"
 			}
 		},
 		"babel-jest": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.8.0.tgz",
-			"integrity": "sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
+			"integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
 			"dev": true,
 			"requires": {
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/transform": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"@types/babel__core": "^7.1.0",
 				"babel-plugin-istanbul": "^5.1.0",
-				"babel-preset-jest": "^24.6.0",
+				"babel-preset-jest": "^24.9.0",
 				"chalk": "^2.4.2",
 				"slash": "^2.0.0"
 			}
@@ -2351,9 +2388,9 @@
 					}
 				},
 				"p-limit": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -2432,9 +2469,9 @@
 					}
 				},
 				"p-limit": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -2458,22 +2495,22 @@
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "24.6.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
-			"integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
+			"integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
 			"dev": true,
 			"requires": {
 				"@types/babel__traverse": "^7.0.6"
 			}
 		},
 		"babel-preset-jest": {
-			"version": "24.6.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
-			"integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
+			"integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
 			"dev": true,
 			"requires": {
 				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-				"babel-plugin-jest-hoist": "^24.6.0"
+				"babel-plugin-jest-hoist": "^24.9.0"
 			}
 		},
 		"bail": {
@@ -2544,9 +2581,9 @@
 			}
 		},
 		"base64-js": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
 			"dev": true
 		},
 		"bcrypt-pbkdf": {
@@ -2979,9 +3016,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000988",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000988.tgz",
-			"integrity": "sha512-lPj3T8poYrRc/bniW5SQPND3GRtSrQdUM/R4mCYTbZxyi3jQiggLvZH4+BYUuX0t4TXjU+vMM7KFDQg+rSzZUQ==",
+			"version": "1.0.30000989",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
+			"integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
 			"dev": true
 		},
 		"capture-exit": {
@@ -3082,9 +3119,9 @@
 			}
 		},
 		"chokidar": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
-			"integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+			"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
 			"dev": true,
 			"requires": {
 				"anymatch": "^2.0.0",
@@ -3185,14 +3222,27 @@
 			}
 		},
 		"cliui": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
 			"dev": true,
 			"requires": {
-				"string-width": "^2.1.1",
-				"strip-ansi": "^4.0.0",
-				"wrap-ansi": "^2.0.0"
+				"string-width": "^3.1.0",
+				"strip-ansi": "^5.2.0",
+				"wrap-ansi": "^5.1.0"
+			},
+			"dependencies": {
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				}
 			}
 		},
 		"clone-deep": {
@@ -3233,12 +3283,6 @@
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
 			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-			"dev": true
-		},
-		"code-point-at": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 			"dev": true
 		},
 		"collapse-white-space": {
@@ -3285,6 +3329,12 @@
 			"version": "2.13.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
 			"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+			"dev": true
+		},
+		"comment-parser": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.6.2.tgz",
+			"integrity": "sha512-Wdms0Q8d4vvb2Yk72OwZjwNWtMklbC5Re7lD9cjCP/AG1fhocmc0TrxGBBAXPLy8fZQPrfHGgyygwI0lA7pbzA==",
 			"dev": true
 		},
 		"commondir": {
@@ -3345,6 +3395,14 @@
 			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.2"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
+				}
 			}
 		},
 		"content-type": {
@@ -3366,6 +3424,14 @@
 			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
+				}
 			}
 		},
 		"cookie": {
@@ -3401,20 +3467,19 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-			"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
-			"integrity": "sha512-Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz",
+			"integrity": "sha512-MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.6.2",
-				"core-js-pure": "3.1.4",
-				"semver": "^6.1.1"
+				"browserslist": "^4.6.6",
+				"semver": "^6.3.0"
 			},
 			"dependencies": {
 				"semver": {
@@ -3424,12 +3489,6 @@
 					"dev": true
 				}
 			}
-		},
-		"core-js-pure": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz",
-			"integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==",
-			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -3790,16 +3849,10 @@
 			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
 			"dev": true
 		},
-		"diff": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-			"dev": true
-		},
 		"diff-sequences": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
-			"integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
+			"integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
 			"dev": true
 		},
 		"diffie-hellman": {
@@ -3958,9 +4011,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.214",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.214.tgz",
-			"integrity": "sha512-SU9yyql6uA0Fc8bWR7sCYNGBtxkC+tQb6UaC7ReaadN42Kx7Ka+dzx3lAIm9Ock+ULEawJuTFcVB2x34uOCg0Q==",
+			"version": "1.3.244",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.244.tgz",
+			"integrity": "sha512-nEfPd2EKnFeLuZ/+JsRG3KixRQwWf2SPpp09ftNt5ouGhg408N759+oXvdXy57+TcM34ykfJYj2JMkc1O3R0lQ==",
 			"dev": true
 		},
 		"elliptic": {
@@ -4186,9 +4239,9 @@
 			"dev": true
 		},
 		"escodegen": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
-			"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+			"integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
 			"dev": true,
 			"requires": {
 				"esprima": "^3.1.3",
@@ -4214,47 +4267,48 @@
 			}
 		},
 		"eslint": {
-			"version": "5.16.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
-			"integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.2.2.tgz",
+			"integrity": "sha512-mf0elOkxHbdyGX1IJEUsNBzCDdyoUgljF3rRlgfyYh0pwGnreLc0jjD6ZuleOibjmnUWZLY2eXwSooeOgGJ2jw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"ajv": "^6.9.1",
+				"ajv": "^6.10.0",
 				"chalk": "^2.1.0",
 				"cross-spawn": "^6.0.5",
 				"debug": "^4.0.1",
 				"doctrine": "^3.0.0",
-				"eslint-scope": "^4.0.3",
-				"eslint-utils": "^1.3.1",
-				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^5.0.1",
+				"eslint-scope": "^5.0.0",
+				"eslint-utils": "^1.4.2",
+				"eslint-visitor-keys": "^1.1.0",
+				"espree": "^6.1.1",
 				"esquery": "^1.0.1",
 				"esutils": "^2.0.2",
 				"file-entry-cache": "^5.0.1",
 				"functional-red-black-tree": "^1.0.1",
-				"glob": "^7.1.2",
+				"glob-parent": "^5.0.0",
 				"globals": "^11.7.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
-				"inquirer": "^6.2.2",
-				"js-yaml": "^3.13.0",
+				"inquirer": "^6.4.1",
+				"is-glob": "^4.0.0",
+				"js-yaml": "^3.13.1",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.3.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"minimatch": "^3.0.4",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.8.2",
-				"path-is-inside": "^1.0.2",
 				"progress": "^2.0.0",
 				"regexpp": "^2.0.1",
-				"semver": "^5.5.1",
-				"strip-ansi": "^4.0.0",
-				"strip-json-comments": "^2.0.1",
+				"semver": "^6.1.2",
+				"strip-ansi": "^5.2.0",
+				"strip-json-comments": "^3.0.1",
 				"table": "^5.2.3",
-				"text-table": "^0.2.0"
+				"text-table": "^0.2.0",
+				"v8-compile-cache": "^2.0.3"
 			},
 			"dependencies": {
 				"cross-spawn": {
@@ -4268,6 +4322,14 @@
 						"semver": "^5.5.0",
 						"shebang-command": "^1.2.0",
 						"which": "^1.2.9"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "5.7.1",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+							"dev": true
+						}
 					}
 				},
 				"doctrine": {
@@ -4280,15 +4342,53 @@
 					}
 				},
 				"eslint-scope": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+					"integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
 					"dev": true,
 					"requires": {
 						"esrecurse": "^4.1.0",
 						"estraverse": "^4.1.1"
 					}
+				},
+				"glob-parent": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
+					"integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
+			}
+		},
+		"eslint-plugin-jest": {
+			"version": "22.15.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.15.2.tgz",
+			"integrity": "sha512-p4NME9TgXIt+KgpxcXyNBvO30ZKxwFAO1dJZBc2OGfDnXVEtPwEyNs95GSr6RIE3xLHdjd8ngDdE2icRRXrbxg==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/experimental-utils": "^1.13.0"
+			}
+		},
+		"eslint-plugin-jsdoc": {
+			"version": "15.8.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-15.8.3.tgz",
+			"integrity": "sha512-p2O6SYetuSD5gWV04HHevIfp2WfimXReYwINuB4iC33hm1jrYoP+t2XbJtCBYvjhoRjjw8w4NfnyZKixte1fug==",
+			"dev": true,
+			"requires": {
+				"comment-parser": "^0.6.2",
+				"debug": "^4.1.1",
+				"jsdoctypeparser": "5.0.1",
+				"lodash": "^4.17.15",
+				"object.entries-ponyfill": "^1.0.1",
+				"regextras": "^0.6.1"
 			}
 		},
 		"eslint-plugin-jsx-a11y": {
@@ -4326,9 +4426,9 @@
 			}
 		},
 		"eslint-plugin-react-hooks": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.1.tgz",
-			"integrity": "sha512-wHhmGJyVuijnYIJXZJHDUF2WM+rJYTjulUTqF9k61d3BTk8etydz+M4dXUVH7M76ZRS85rqBTCx0Es/lLsrjnA==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
+			"integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
 			"dev": true
 		},
 		"eslint-scope": {
@@ -4351,26 +4451,26 @@
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
 			"dev": true
 		},
 		"espree": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
-			"integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
+			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^6.0.7",
-				"acorn-jsx": "^5.0.0",
-				"eslint-visitor-keys": "^1.0.0"
+				"acorn": "^7.0.0",
+				"acorn-jsx": "^5.0.2",
+				"eslint-visitor-keys": "^1.1.0"
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-					"integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
+					"integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
 					"dev": true
 				}
 			}
@@ -4400,9 +4500,9 @@
 			}
 		},
 		"estraverse": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true
 		},
 		"esutils": {
@@ -4544,17 +4644,17 @@
 			}
 		},
 		"expect": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
-			"integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
+			"integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"ansi-styles": "^3.2.0",
-				"jest-get-type": "^24.8.0",
-				"jest-matcher-utils": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-regex-util": "^24.3.0"
+				"jest-get-type": "^24.9.0",
+				"jest-matcher-utils": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-regex-util": "^24.9.0"
 			}
 		},
 		"expect-puppeteer": {
@@ -4620,6 +4720,12 @@
 					"version": "6.7.0",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
 					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+					"dev": true
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 					"dev": true
 				}
 			}
@@ -4831,14 +4937,6 @@
 				"promise": "^7.1.1",
 				"setimmediate": "^1.0.5",
 				"ua-parser-js": "^0.7.18"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-					"dev": true
-				}
 			}
 		},
 		"fd-slicer": {
@@ -5068,6 +5166,17 @@
 				"flatted": "^2.0.0",
 				"rimraf": "2.6.3",
 				"write": "1.0.3"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
 			}
 		},
 		"flatted": {
@@ -5752,9 +5861,9 @@
 			"dev": true
 		},
 		"get-caller-file": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
 		},
 		"get-stdin": {
@@ -5961,9 +6070,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-			"integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+			"integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
 			"dev": true
 		},
 		"growly": {
@@ -6146,10 +6255,13 @@
 			}
 		},
 		"hoist-non-react-statics": {
-			"version": "2.5.5",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
-			"dev": true
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+			"integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+			"dev": true,
+			"requires": {
+				"react-is": "^16.7.0"
+			}
 		},
 		"homedir-polyfill": {
 			"version": "1.0.3",
@@ -6167,30 +6279,10 @@
 			"dev": true
 		},
 		"hosted-git-info": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz",
-			"integrity": "sha512-CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==",
-			"dev": true,
-			"requires": {
-				"lru-cache": "^5.1.1"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-					"dev": true,
-					"requires": {
-						"yallist": "^3.0.2"
-					}
-				},
-				"yallist": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-					"dev": true
-				}
-			}
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+			"integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+			"dev": true
 		},
 		"html-element-map": {
 			"version": "1.1.0",
@@ -6381,9 +6473,9 @@
 					}
 				},
 				"p-limit": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -6456,9 +6548,9 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
-			"integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+			"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.2.0",
@@ -6474,17 +6566,6 @@
 				"string-width": "^2.1.0",
 				"strip-ansi": "^5.1.0",
 				"through": "^2.3.6"
-			},
-			"dependencies": {
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
 			}
 		},
 		"interpret": {
@@ -7006,71 +7087,71 @@
 			}
 		},
 		"jest": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-24.8.0.tgz",
-			"integrity": "sha512-o0HM90RKFRNWmAWvlyV8i5jGZ97pFwkeVoGvPW1EtLTgJc2+jcuqcbbqcSZLE/3f2S5pt0y2ZBETuhpWNl1Reg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
+			"integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
 			"dev": true,
 			"requires": {
 				"import-local": "^2.0.0",
-				"jest-cli": "^24.8.0"
+				"jest-cli": "^24.9.0"
 			},
 			"dependencies": {
 				"jest-cli": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.8.0.tgz",
-					"integrity": "sha512-+p6J00jSMPQ116ZLlHJJvdf8wbjNbZdeSX9ptfHX06/MSNaXmKihQzx5vQcw0q2G6JsdVkUIdWbOWtSnaYs3yA==",
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
+					"integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
 					"dev": true,
 					"requires": {
-						"@jest/core": "^24.8.0",
-						"@jest/test-result": "^24.8.0",
-						"@jest/types": "^24.8.0",
+						"@jest/core": "^24.9.0",
+						"@jest/test-result": "^24.9.0",
+						"@jest/types": "^24.9.0",
 						"chalk": "^2.0.1",
 						"exit": "^0.1.2",
 						"import-local": "^2.0.0",
 						"is-ci": "^2.0.0",
-						"jest-config": "^24.8.0",
-						"jest-util": "^24.8.0",
-						"jest-validate": "^24.8.0",
+						"jest-config": "^24.9.0",
+						"jest-util": "^24.9.0",
+						"jest-validate": "^24.9.0",
 						"prompts": "^2.0.1",
 						"realpath-native": "^1.1.0",
-						"yargs": "^12.0.2"
+						"yargs": "^13.3.0"
 					}
 				}
 			}
 		},
 		"jest-changed-files": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.8.0.tgz",
-			"integrity": "sha512-qgANC1Yrivsq+UrLXsvJefBKVoCsKB0Hv+mBb6NMjjZ90wwxCDmU3hsCXBya30cH+LnPYjwgcU65i6yJ5Nfuug==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
+			"integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"execa": "^1.0.0",
 				"throat": "^4.0.0"
 			}
 		},
 		"jest-config": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.8.0.tgz",
-			"integrity": "sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
+			"integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"babel-jest": "^24.8.0",
+				"@jest/test-sequencer": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"babel-jest": "^24.9.0",
 				"chalk": "^2.0.1",
 				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^24.8.0",
-				"jest-environment-node": "^24.8.0",
-				"jest-get-type": "^24.8.0",
-				"jest-jasmine2": "^24.8.0",
+				"jest-environment-jsdom": "^24.9.0",
+				"jest-environment-node": "^24.9.0",
+				"jest-get-type": "^24.9.0",
+				"jest-jasmine2": "^24.9.0",
 				"jest-regex-util": "^24.3.0",
-				"jest-resolve": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"jest-validate": "^24.8.0",
+				"jest-resolve": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"jest-validate": "^24.9.0",
 				"micromatch": "^3.1.10",
-				"pretty-format": "^24.8.0",
+				"pretty-format": "^24.9.0",
 				"realpath-native": "^1.1.0"
 			}
 		},
@@ -7090,64 +7171,64 @@
 			}
 		},
 		"jest-diff": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
-			"integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
+			"integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
-				"diff-sequences": "^24.3.0",
-				"jest-get-type": "^24.8.0",
-				"pretty-format": "^24.8.0"
+				"diff-sequences": "^24.9.0",
+				"jest-get-type": "^24.9.0",
+				"pretty-format": "^24.9.0"
 			}
 		},
 		"jest-docblock": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
-			"integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
+			"integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
 			"dev": true,
 			"requires": {
 				"detect-newline": "^2.1.0"
 			}
 		},
 		"jest-each": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.8.0.tgz",
-			"integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
+			"integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"chalk": "^2.0.1",
-				"jest-get-type": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"pretty-format": "^24.8.0"
+				"jest-get-type": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"pretty-format": "^24.9.0"
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz",
-			"integrity": "sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
+			"integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.8.0",
-				"@jest/fake-timers": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"jest-mock": "^24.8.0",
-				"jest-util": "^24.8.0",
+				"@jest/environment": "^24.9.0",
+				"@jest/fake-timers": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"jest-mock": "^24.9.0",
+				"jest-util": "^24.9.0",
 				"jsdom": "^11.5.1"
 			}
 		},
 		"jest-environment-node": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.8.0.tgz",
-			"integrity": "sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
+			"integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.8.0",
-				"@jest/fake-timers": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"jest-mock": "^24.8.0",
-				"jest-util": "^24.8.0"
+				"@jest/environment": "^24.9.0",
+				"@jest/fake-timers": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"jest-mock": "^24.9.0",
+				"jest-util": "^24.9.0"
 			}
 		},
 		"jest-environment-puppeteer": {
@@ -7163,85 +7244,86 @@
 			}
 		},
 		"jest-get-type": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
-			"integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+			"integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "24.8.1",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.1.tgz",
-			"integrity": "sha512-SwaxMGVdAZk3ernAx2Uv2sorA7jm3Kx+lR0grp6rMmnY06Kn/urtKx1LPN2mGTea4fCT38impYT28FfcLUhX0g==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
+			"integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"anymatch": "^2.0.0",
 				"fb-watchman": "^2.0.0",
 				"fsevents": "^1.2.7",
 				"graceful-fs": "^4.1.15",
 				"invariant": "^2.2.4",
-				"jest-serializer": "^24.4.0",
-				"jest-util": "^24.8.0",
-				"jest-worker": "^24.6.0",
+				"jest-serializer": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"jest-worker": "^24.9.0",
 				"micromatch": "^3.1.10",
 				"sane": "^4.0.3",
 				"walker": "^1.0.7"
 			}
 		},
 		"jest-jasmine2": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
-			"integrity": "sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
+			"integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
 			"dev": true,
 			"requires": {
 				"@babel/traverse": "^7.1.0",
-				"@jest/environment": "^24.8.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/environment": "^24.9.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"chalk": "^2.0.1",
 				"co": "^4.6.0",
-				"expect": "^24.8.0",
+				"expect": "^24.9.0",
 				"is-generator-fn": "^2.0.0",
-				"jest-each": "^24.8.0",
-				"jest-matcher-utils": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-runtime": "^24.8.0",
-				"jest-snapshot": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"pretty-format": "^24.8.0",
+				"jest-each": "^24.9.0",
+				"jest-matcher-utils": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-runtime": "^24.9.0",
+				"jest-snapshot": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"pretty-format": "^24.9.0",
 				"throat": "^4.0.0"
 			}
 		},
 		"jest-leak-detector": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz",
-			"integrity": "sha512-cG0yRSK8A831LN8lIHxI3AblB40uhv0z+SsQdW3GoMMVcK+sJwrIIyax5tu3eHHNJ8Fu6IMDpnLda2jhn2pD/g==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
+			"integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
 			"dev": true,
 			"requires": {
-				"pretty-format": "^24.8.0"
+				"jest-get-type": "^24.9.0",
+				"pretty-format": "^24.9.0"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
-			"integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+			"integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
-				"jest-diff": "^24.8.0",
-				"jest-get-type": "^24.8.0",
-				"pretty-format": "^24.8.0"
+				"jest-diff": "^24.9.0",
+				"jest-get-type": "^24.9.0",
+				"pretty-format": "^24.9.0"
 			}
 		},
 		"jest-message-util": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
-			"integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
+			"integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"@types/stack-utils": "^1.0.1",
 				"chalk": "^2.0.1",
 				"micromatch": "^3.1.10",
@@ -7250,12 +7332,12 @@
 			}
 		},
 		"jest-mock": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz",
-			"integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
+			"integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0"
+				"@jest/types": "^24.9.0"
 			}
 		},
 		"jest-pnp-resolver": {
@@ -7275,18 +7357,18 @@
 			}
 		},
 		"jest-regex-util": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
-			"integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+			"integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
 			"dev": true
 		},
 		"jest-resolve": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
-			"integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
+			"integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"browser-resolve": "^1.11.3",
 				"chalk": "^2.0.1",
 				"jest-pnp-resolver": "^1.2.1",
@@ -7294,111 +7376,120 @@
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.8.0.tgz",
-			"integrity": "sha512-hyK1qfIf/krV+fSNyhyJeq3elVMhK9Eijlwy+j5jqmZ9QsxwKBiP6qukQxaHtK8k6zql/KYWwCTQ+fDGTIJauw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
+			"integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"jest-regex-util": "^24.3.0",
-				"jest-snapshot": "^24.8.0"
+				"jest-snapshot": "^24.9.0"
 			}
 		},
 		"jest-runner": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.8.0.tgz",
-			"integrity": "sha512-utFqC5BaA3JmznbissSs95X1ZF+d+4WuOWwpM9+Ak356YtMhHE/GXUondZdcyAAOTBEsRGAgH/0TwLzfI9h7ow==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
+			"integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
 			"dev": true,
 			"requires": {
 				"@jest/console": "^24.7.1",
-				"@jest/environment": "^24.8.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/environment": "^24.9.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"chalk": "^2.4.2",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.1.15",
-				"jest-config": "^24.8.0",
+				"jest-config": "^24.9.0",
 				"jest-docblock": "^24.3.0",
-				"jest-haste-map": "^24.8.0",
-				"jest-jasmine2": "^24.8.0",
-				"jest-leak-detector": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-resolve": "^24.8.0",
-				"jest-runtime": "^24.8.0",
-				"jest-util": "^24.8.0",
+				"jest-haste-map": "^24.9.0",
+				"jest-jasmine2": "^24.9.0",
+				"jest-leak-detector": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-resolve": "^24.9.0",
+				"jest-runtime": "^24.9.0",
+				"jest-util": "^24.9.0",
 				"jest-worker": "^24.6.0",
 				"source-map-support": "^0.5.6",
 				"throat": "^4.0.0"
 			}
 		},
 		"jest-runtime": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.8.0.tgz",
-			"integrity": "sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
+			"integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
 			"dev": true,
 			"requires": {
 				"@jest/console": "^24.7.1",
-				"@jest/environment": "^24.8.0",
+				"@jest/environment": "^24.9.0",
 				"@jest/source-map": "^24.3.0",
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"@types/yargs": "^12.0.2",
+				"@jest/transform": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"@types/yargs": "^13.0.0",
 				"chalk": "^2.0.1",
 				"exit": "^0.1.2",
 				"glob": "^7.1.3",
 				"graceful-fs": "^4.1.15",
-				"jest-config": "^24.8.0",
-				"jest-haste-map": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-mock": "^24.8.0",
+				"jest-config": "^24.9.0",
+				"jest-haste-map": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-mock": "^24.9.0",
 				"jest-regex-util": "^24.3.0",
-				"jest-resolve": "^24.8.0",
-				"jest-snapshot": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"jest-validate": "^24.8.0",
+				"jest-resolve": "^24.9.0",
+				"jest-snapshot": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"jest-validate": "^24.9.0",
 				"realpath-native": "^1.1.0",
 				"slash": "^2.0.0",
 				"strip-bom": "^3.0.0",
-				"yargs": "^12.0.2"
+				"yargs": "^13.3.0"
 			}
 		},
 		"jest-serializer": {
-			"version": "24.4.0",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz",
-			"integrity": "sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
+			"integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==",
 			"dev": true
 		},
 		"jest-snapshot": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
-			"integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
+			"integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0",
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"chalk": "^2.0.1",
-				"expect": "^24.8.0",
-				"jest-diff": "^24.8.0",
-				"jest-matcher-utils": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-resolve": "^24.8.0",
+				"expect": "^24.9.0",
+				"jest-diff": "^24.9.0",
+				"jest-get-type": "^24.9.0",
+				"jest-matcher-utils": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-resolve": "^24.9.0",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^24.8.0",
-				"semver": "^5.5.0"
+				"pretty-format": "^24.9.0",
+				"semver": "^6.2.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"jest-util": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.8.0.tgz",
-			"integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
+			"integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/fake-timers": "^24.8.0",
-				"@jest/source-map": "^24.3.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/console": "^24.9.0",
+				"@jest/fake-timers": "^24.9.0",
+				"@jest/source-map": "^24.9.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"callsites": "^3.0.0",
 				"chalk": "^2.0.1",
 				"graceful-fs": "^4.1.15",
@@ -7417,41 +7508,41 @@
 			}
 		},
 		"jest-validate": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.8.0.tgz",
-			"integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
+			"integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
-				"camelcase": "^5.0.0",
+				"@jest/types": "^24.9.0",
+				"camelcase": "^5.3.1",
 				"chalk": "^2.0.1",
-				"jest-get-type": "^24.8.0",
-				"leven": "^2.1.0",
-				"pretty-format": "^24.8.0"
+				"jest-get-type": "^24.9.0",
+				"leven": "^3.1.0",
+				"pretty-format": "^24.9.0"
 			}
 		},
 		"jest-watcher": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.8.0.tgz",
-			"integrity": "sha512-SBjwHt5NedQoVu54M5GEx7cl7IGEFFznvd/HNT8ier7cCAx/Qgu9ZMlaTQkvK22G1YOpcWBLQPFSImmxdn3DAw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.9.0.tgz",
+			"integrity": "sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"@types/yargs": "^12.0.9",
+				"@jest/test-result": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"@types/yargs": "^13.0.0",
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.1",
-				"jest-util": "^24.8.0",
+				"jest-util": "^24.9.0",
 				"string-length": "^2.0.0"
 			}
 		},
 		"jest-worker": {
-			"version": "24.6.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
-			"integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
+			"integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
 			"dev": true,
 			"requires": {
-				"merge-stream": "^1.0.1",
+				"merge-stream": "^2.0.0",
 				"supports-color": "^6.1.0"
 			},
 			"dependencies": {
@@ -7492,6 +7583,12 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true
+		},
+		"jsdoctypeparser": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-5.0.1.tgz",
+			"integrity": "sha512-dYwcK6TKzvq+ZKtbp4sbQSW9JMo6s+4YFfUs5D/K7bZsn3s1NhEhZ+jmIPzby0HbkbECBe+hNPEa6a+E21o94w==",
 			"dev": true
 		},
 		"jsdom": {
@@ -7649,9 +7746,9 @@
 			"dev": true
 		},
 		"leven": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
 			"dev": true
 		},
 		"levn": {
@@ -7748,6 +7845,12 @@
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"dev": true
+		},
+		"lodash.unescape": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+			"integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
 			"dev": true
 		},
 		"log-symbols": {
@@ -8006,13 +8109,10 @@
 			"dev": true
 		},
 		"merge-stream": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.0.1"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true
 		},
 		"merge2": {
 			"version": "1.2.4",
@@ -8372,9 +8472,9 @@
 			"dev": true
 		},
 		"node-notifier": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.1.tgz",
-			"integrity": "sha512-p52B+onAEHKW1OF9MGO/S7k/ahGEHfhP5/tvwYzog/5XLYOd8ZuD6vdNZdUuWMONRnKPneXV43v3s6Snx1wsCQ==",
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
+			"integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
 			"dev": true,
 			"requires": {
 				"growly": "^1.3.0",
@@ -8385,9 +8485,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.26",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-			"integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
+			"version": "1.1.28",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.28.tgz",
+			"integrity": "sha512-AQw4emh6iSXnCpDiFe0phYcThiccmkNWMZnFZ+lDJjAP8J0m2fVd59duvUUyuTirQOhIAajTFkzG6FHCLBO59g==",
 			"dev": true,
 			"requires": {
 				"semver": "^5.3.0"
@@ -8445,9 +8545,15 @@
 			},
 			"dependencies": {
 				"ignore": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
-					"integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+					"dev": true
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 					"dev": true
 				}
 			}
@@ -8474,12 +8580,6 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
 			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
-			"dev": true
-		},
-		"number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 			"dev": true
 		},
 		"nwsapi": {
@@ -8587,6 +8687,12 @@
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3"
 			}
+		},
+		"object.entries-ponyfill": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object.entries-ponyfill/-/object.entries-ponyfill-1.0.1.tgz",
+			"integrity": "sha1-Kavfd8v70mVm3RqiTp2I9lQz0lY=",
+			"dev": true
 		},
 		"object.fromentries": {
 			"version": "2.0.0",
@@ -9016,9 +9122,9 @@
 			"dev": true
 		},
 		"portfinder": {
-			"version": "1.0.21",
-			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.21.tgz",
-			"integrity": "sha512-ESabpDCzmBS3ekHbmpAIiESq3udRsCBGiBZLsC+HgBKv2ezb0R4oG+7RnYEVZ/ZCfhel5Tx3UzdNWA0Lox2QCA==",
+			"version": "1.0.23",
+			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.23.tgz",
+			"integrity": "sha512-B729mL/uLklxtxuiJKfQ84WPxNw5a7Yhx3geQZdcA4GjNjZSTSSMMWyoennMVnTWSmAR0lMdzWYN0JLnHrg1KQ==",
 			"dev": true,
 			"requires": {
 				"async": "^1.5.2",
@@ -9202,12 +9308,12 @@
 			"dev": true
 		},
 		"pretty-format": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
-			"integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+			"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"ansi-regex": "^4.0.0",
 				"ansi-styles": "^3.2.0",
 				"react-is": "^16.8.4"
@@ -9360,28 +9466,28 @@
 			"dev": true
 		},
 		"puppeteer": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.6.1.tgz",
-			"integrity": "sha512-qz6DLwK+PhlBMjJZOMOsgVCnweYLtmiqnmJYUDPT++ElMz+cQgbsCNKPw4YDVpg3RTbsRX/pqQqr20zrp0cuKw==",
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.19.0.tgz",
+			"integrity": "sha512-2S6E6ygpoqcECaagDbBopoSOPDv0pAZvTbnBgUY+6hq0/XDFDOLEMNlHF/SKJlzcaZ9ckiKjKDuueWI3FN/WXw==",
 			"dev": true,
 			"requires": {
-				"debug": "^3.1.0",
+				"debug": "^4.1.0",
 				"extract-zip": "^1.6.6",
 				"https-proxy-agent": "^2.2.1",
 				"mime": "^2.0.3",
-				"progress": "^2.0.0",
+				"progress": "^2.0.1",
 				"proxy-from-env": "^1.0.0",
 				"rimraf": "^2.6.1",
-				"ws": "^5.1.1"
+				"ws": "^6.1.0"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+				"ws": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+					"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"async-limiter": "~1.0.0"
 					}
 				}
 			}
@@ -9473,9 +9579,9 @@
 			}
 		},
 		"re-resizable": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-5.0.1.tgz",
-			"integrity": "sha512-Iy8v5li7bhNBDxCN1DbA4l6G2Hk8NCZtcExoI1D+5pfvKyQcH8LH2P5h3DGoEfHhs0uyyRC1Qx8bHBomfrmxgA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.0.0.tgz",
+			"integrity": "sha512-RTrnhbGgYyZ4hTc6db4JeMnRfmloEPWtuYaXZEa2PRaEC4mreWNFnZtMVsHil3z3iX+WchD+da8BLlTJBcstMA==",
 			"dev": true,
 			"requires": {
 				"fast-memoize": "^2.5.1"
@@ -9500,15 +9606,6 @@
 			"requires": {
 				"fbjs": "^0.8.4",
 				"object-assign": "^4.1.0"
-			}
-		},
-		"react-click-outside": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-3.0.1.tgz",
-			"integrity": "sha512-d0KWFvBt+esoZUF15rL2UBB7jkeAqLU8L/Ny35oLK6fW6mIbOv/ChD+ExF4sR9PD26kVx+9hNfD0FTIqRZEyRQ==",
-			"dev": true,
-			"requires": {
-				"hoist-non-react-statics": "^2.1.1"
 			}
 		},
 		"react-dates": {
@@ -9542,30 +9639,18 @@
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
 				"scheduler": "^0.15.0"
-			},
-			"dependencies": {
-				"scheduler": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
-					"integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1"
-					}
-				}
 			}
 		},
 		"react-is": {
-			"version": "16.8.6",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-			"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+			"version": "16.9.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
+			"integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
 			"dev": true
 		},
 		"react-moment-proptypes": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.6.0.tgz",
-			"integrity": "sha512-4h7EuhDMTzQqZ+02KUUO+AVA7PqhbD88yXB740nFpNDyDS/bj9jiPyn2rwr9sa8oDyaE1ByFN9+t5XPyPTmN6g==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.7.0.tgz",
+			"integrity": "sha512-ZbOn/P4u469WEGAw5hgkS/E+g1YZqdves2BjYsLluJobzUZCtManhjHiZKjniBVT7MSHM6D/iKtRVzlXVv3ikA==",
 			"dev": true,
 			"requires": {
 				"moment": ">=1.6.0"
@@ -9604,15 +9689,15 @@
 			}
 		},
 		"react-test-renderer": {
-			"version": "16.8.6",
-			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.6.tgz",
-			"integrity": "sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==",
+			"version": "16.9.0",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.9.0.tgz",
+			"integrity": "sha512-R62stB73qZyhrJo7wmCW9jgl/07ai+YzvouvCXIJLBkRlRqLx4j9RqcLEAfNfU3OxTGucqR2Whmn3/Aad6L3hQ==",
 			"dev": true,
 			"requires": {
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
-				"react-is": "^16.8.6",
-				"scheduler": "^0.13.6"
+				"react-is": "^16.9.0",
+				"scheduler": "^0.15.0"
 			}
 		},
 		"react-with-direction": {
@@ -9629,6 +9714,14 @@
 				"object.assign": "^4.1.0",
 				"object.values": "^1.0.4",
 				"prop-types": "^15.6.0"
+			},
+			"dependencies": {
+				"hoist-non-react-statics": {
+					"version": "2.5.5",
+					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+					"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+					"dev": true
+				}
 			}
 		},
 		"react-with-styles": {
@@ -9641,17 +9734,6 @@
 				"object.assign": "^4.1.0",
 				"prop-types": "^15.6.2",
 				"react-with-direction": "^1.3.0"
-			},
-			"dependencies": {
-				"hoist-non-react-statics": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-					"integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
-					"dev": true,
-					"requires": {
-						"react-is": "^16.7.0"
-					}
-				}
 			}
 		},
 		"react-with-styles-interface-css": {
@@ -9778,6 +9860,14 @@
 				"safe-buffer": "~5.1.1",
 				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
+				}
 			}
 		},
 		"readdirp": {
@@ -9867,9 +9957,9 @@
 			}
 		},
 		"regexp-tree": {
-			"version": "0.1.11",
-			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.11.tgz",
-			"integrity": "sha512-7/l/DgapVVDzZobwMCCgMlqiqyLFJ0cduo/j+3BcDJIB+yJdsYCfKuI3l/04NV+H/rfNRdPIDbXNZHM9XvQatg==",
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.12.tgz",
+			"integrity": "sha512-TsXZ8+cv2uxMEkLfgwO0E068gsNMLfuYwMMhiUxf0Kw2Vcgzq93vgl6wIlIYuPmfMqMjfQ9zAporiozqCnwLuQ==",
 			"dev": true
 		},
 		"regexpp": {
@@ -9879,18 +9969,24 @@
 			"dev": true
 		},
 		"regexpu-core": {
-			"version": "4.5.4",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-			"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
+			"integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
 			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0",
-				"regenerate-unicode-properties": "^8.0.2",
+				"regenerate-unicode-properties": "^8.1.0",
 				"regjsgen": "^0.5.0",
 				"regjsparser": "^0.6.0",
 				"unicode-match-property-ecmascript": "^1.0.4",
 				"unicode-match-property-value-ecmascript": "^1.1.0"
 			}
+		},
+		"regextras": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.6.1.tgz",
+			"integrity": "sha512-EzIHww9xV2Kpqx+corS/I7OBmf2rZ0pKKJPsw5Dc+l6Zq1TslDmtRIP9maVn3UH+72MIXmn8zzDgP07ihQogUA==",
+			"dev": true
 		},
 		"regjsgen": {
 			"version": "0.5.0",
@@ -10159,9 +10255,9 @@
 			"dev": true
 		},
 		"rimraf": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
@@ -10239,9 +10335,9 @@
 			}
 		},
 		"safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
 			"dev": true
 		},
 		"safe-json-parse": {
@@ -10289,9 +10385,9 @@
 			"dev": true
 		},
 		"scheduler": {
-			"version": "0.13.6",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-			"integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
+			"integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
 			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
@@ -10315,9 +10411,9 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "5.7.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-			"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 			"dev": true
 		},
 		"send": {
@@ -10373,9 +10469,9 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
-			"integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.0.tgz",
+			"integrity": "sha512-UkGlcYMtw4d9w7YfCtJFgdRTps8N4L0A48R+SmcGL57ki1+yHwJXnalk5bjgrw+ljv6SfzjzPjhohod2qllg/Q==",
 			"dev": true
 		},
 		"serve-static": {
@@ -10761,9 +10857,9 @@
 			}
 		},
 		"sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
 			"dev": true
 		},
 		"sshpk": {
@@ -10884,6 +10980,23 @@
 			"requires": {
 				"astral-regex": "^1.0.0",
 				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"string-template": {
@@ -10900,6 +11013,23 @@
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"string.prototype.trim": {
@@ -10920,6 +11050,14 @@
 			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
+				}
 			}
 		},
 		"stringify-entities": {
@@ -10935,20 +11073,12 @@
 			}
 		},
 		"strip-ansi": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				}
+				"ansi-regex": "^4.1.0"
 			}
 		},
 		"strip-bom": {
@@ -10970,9 +11100,9 @@
 			"dev": true
 		},
 		"strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+			"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
 			"dev": true
 		},
 		"style-search": {
@@ -11066,9 +11196,15 @@
 					}
 				},
 				"ignore": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
-					"integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+					"dev": true
+				},
+				"leven": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+					"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
 					"dev": true
 				},
 				"pify": {
@@ -11086,15 +11222,6 @@
 						"emoji-regex": "^7.0.1",
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
 					}
 				}
 			}
@@ -11126,16 +11253,16 @@
 			}
 		},
 		"stylelint-scss": {
-			"version": "3.9.3",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.9.3.tgz",
-			"integrity": "sha512-pLLpwSpUwiqpAga/C22ZuN/d5ql2zVWGzG8MO+P3DQYcDNue3eZGvda/bJdkx4mDcVy06jlDt+BgSvMYUrwleQ==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.10.0.tgz",
+			"integrity": "sha512-cz0CiJ/CEOY9arl1OA7Epb68F+L5iXBVZSOzTdK5AymoTM5dpll4QGeggMIsKN5Put8ZtQ3OwzYXexkPKs15PQ==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.15",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
 				"postcss-selector-parser": "^6.0.2",
-				"postcss-value-parser": "^4.0.0"
+				"postcss-value-parser": "^4.0.2"
 			},
 			"dependencies": {
 				"postcss-selector-parser": {
@@ -11150,9 +11277,9 @@
 					}
 				},
 				"postcss-value-parser": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.0.tgz",
-					"integrity": "sha512-ESPktioptiSUchCKgggAkzdmkgzKfmp0EU8jXH+5kbIUB+unr0Y4CY9SRMvibuvYUBjNh1ACLbxqYNpdTQOteQ==",
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+					"integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
 					"dev": true
 				}
 			}
@@ -11194,9 +11321,9 @@
 			"dev": true
 		},
 		"table": {
-			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/table/-/table-5.4.5.tgz",
-			"integrity": "sha512-oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==",
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+			"integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.10.2",
@@ -11214,15 +11341,6 @@
 						"emoji-regex": "^7.0.1",
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
 					}
 				}
 			}
@@ -11274,9 +11392,9 @@
 					}
 				},
 				"p-limit": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -11316,9 +11434,9 @@
 			"dev": true
 		},
 		"thread-loader": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.2.tgz",
-			"integrity": "sha512-7xpuc9Ifg6WU+QYw/8uUqNdRwMD+N5gjwHKMqETrs96Qn+7BHwECpt2Brzr4HFlf4IAkZsayNhmGdbkBsTJ//w==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.3.tgz",
+			"integrity": "sha512-wNrVKH2Lcf8ZrWxDF/khdlLlsTMczdcwPA9VEK4c2exlEPynYWxi9op3nPTo5lAnDIkE0rQEB3VBP+4Zncc9Hg==",
 			"dev": true,
 			"requires": {
 				"loader-runner": "^2.3.1",
@@ -11349,9 +11467,9 @@
 			}
 		},
 		"timers-browserify": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-			"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
+			"integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
 			"dev": true,
 			"requires": {
 				"setimmediate": "^1.0.4"
@@ -11571,6 +11689,12 @@
 			"requires": {
 				"prelude-ls": "~1.1.2"
 			}
+		},
+		"type-fest": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+			"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+			"dev": true
 		},
 		"type-is": {
 			"version": "1.6.18",
@@ -11905,15 +12029,15 @@
 			"dev": true
 		},
 		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
 			"dev": true
 		},
 		"v8-compile-cache": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
-			"integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+			"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
@@ -12179,9 +12303,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-					"integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+					"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
 					"dev": true
 				},
 				"commander": {
@@ -12202,9 +12326,9 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.6.tgz",
-			"integrity": "sha512-0vEa83M7kJtxK/jUhlpZ27WHIOndz5mghWL2O53kiDoA9DIxSKnfqB92LoqEn77cT4f3H2cZm1BMEat/6AZz3A==",
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.7.tgz",
+			"integrity": "sha512-OhTUCttAsr+IZSMVwGROGRHvT+QAs8H6/mHIl4SvhAwYywjiylYjpwybGx7WQ9Hkb45FhjtsymkwiRRbGJ1SZQ==",
 			"dev": true,
 			"requires": {
 				"chalk": "2.4.2",
@@ -12220,17 +12344,6 @@
 				"yargs": "13.2.4"
 			},
 			"dependencies": {
-				"cliui": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-					"dev": true,
-					"requires": {
-						"string-width": "^3.1.0",
-						"strip-ansi": "^5.2.0",
-						"wrap-ansi": "^5.1.0"
-					}
-				},
 				"cross-spawn": {
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -12252,12 +12365,6 @@
 					"requires": {
 						"locate-path": "^3.0.0"
 					}
-				},
-				"get-caller-file": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-					"dev": true
 				},
 				"global-modules": {
 					"version": "2.0.0",
@@ -12290,9 +12397,9 @@
 					}
 				},
 				"p-limit": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -12324,15 +12431,6 @@
 						"strip-ansi": "^5.1.0"
 					}
 				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
 				"supports-color": {
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
@@ -12342,16 +12440,11 @@
 						"has-flag": "^3.0.0"
 					}
 				},
-				"wrap-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.0",
-						"string-width": "^3.0.0",
-						"strip-ansi": "^5.0.0"
-					}
+				"v8-compile-cache": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
+					"integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
+					"dev": true
 				},
 				"yargs": {
 					"version": "13.2.4",
@@ -12371,16 +12464,6 @@
 						"y18n": "^4.0.0",
 						"yargs-parser": "^13.1.0"
 					}
-				},
-				"yargs-parser": {
-					"version": "13.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-					"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
 				}
 			}
 		},
@@ -12395,9 +12478,9 @@
 			}
 		},
 		"webpack-sources": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.2.tgz",
-			"integrity": "sha512-V/mHhu5RzLPYVY3Aa+ogcoLqdZU+XdOf0VCLuqSDLJ6oo5lk7Q1n9kG5cySidY/SzXfXwS+CASg4z00q7gIhRQ==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+			"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
 			"dev": true,
 			"requires": {
 				"source-list-map": "^2.0.0",
@@ -12492,48 +12575,25 @@
 			}
 		},
 		"wrap-ansi": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
 			"dev": true,
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1"
+				"ansi-styles": "^3.2.0",
+				"string-width": "^3.0.0",
+				"strip-ansi": "^5.0.0"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
 				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
 					}
 				}
 			}
@@ -12604,23 +12664,21 @@
 			"dev": true
 		},
 		"yargs": {
-			"version": "12.0.5",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-			"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+			"integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
 			"dev": true,
 			"requires": {
-				"cliui": "^4.0.0",
-				"decamelize": "^1.2.0",
+				"cliui": "^5.0.0",
 				"find-up": "^3.0.0",
-				"get-caller-file": "^1.0.1",
-				"os-locale": "^3.0.0",
+				"get-caller-file": "^2.0.1",
 				"require-directory": "^2.1.1",
-				"require-main-filename": "^1.0.1",
+				"require-main-filename": "^2.0.0",
 				"set-blocking": "^2.0.0",
-				"string-width": "^2.0.0",
+				"string-width": "^3.0.0",
 				"which-module": "^2.0.0",
-				"y18n": "^3.2.1 || ^4.0.0",
-				"yargs-parser": "^11.1.1"
+				"y18n": "^4.0.0",
+				"yargs-parser": "^13.1.1"
 			},
 			"dependencies": {
 				"find-up": {
@@ -12643,9 +12701,9 @@
 					}
 				},
 				"p-limit": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -12666,18 +12724,23 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
-				"require-main-filename": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-					"dev": true
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
 				}
 			}
 		},
 		"yargs-parser": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-			"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+			"version": "13.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+			"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
 			"dev": true,
 			"requires": {
 				"camelcase": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,18 +14,18 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
-			"integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
+			"integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.5.5",
-				"@babel/helpers": "^7.5.5",
-				"@babel/parser": "^7.5.5",
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5",
+				"@babel/generator": "^7.6.0",
+				"@babel/helpers": "^7.6.0",
+				"@babel/parser": "^7.6.0",
+				"@babel/template": "^7.6.0",
+				"@babel/traverse": "^7.6.0",
+				"@babel/types": "^7.6.0",
 				"convert-source-map": "^1.1.0",
 				"debug": "^4.1.0",
 				"json5": "^2.1.0",
@@ -36,12 +36,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-			"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz",
+			"integrity": "sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.5.5",
+				"@babel/types": "^7.6.0",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.13",
 				"source-map": "^0.5.0",
@@ -251,14 +251,14 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
-			"integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.0.tgz",
+			"integrity": "sha512-W9kao7OBleOjfXtFGgArGRX6eCP0UEcA2ZWEWNkJdRZnHhW4eEbeswbG3EwaRsnQUAEGWYgMq1HsIXuNNNy2eQ==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5"
+				"@babel/template": "^7.6.0",
+				"@babel/traverse": "^7.6.0",
+				"@babel/types": "^7.6.0"
 			}
 		},
 		"@babel/highlight": {
@@ -273,9 +273,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-			"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
+			"integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
@@ -424,9 +424,9 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz",
-			"integrity": "sha512-82A3CLRRdYubkG85lKwhZB0WZoHxLGsJdux/cOVaJCJpvYFl1LVzAIFyRsa7CvXqW8rBM4Zf3Bfn8PHt5DP0Sg==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.0.tgz",
+			"integrity": "sha512-tIt4E23+kw6TgL/edACZwP1OUKrjOTyMrFMLoT5IOFrfMRabCgekjqFd5o6PaAMildBu46oFkekIdMuGkkPEpA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -459,9 +459,9 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
-			"integrity": "sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
+			"integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -546,9 +546,9 @@
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
-			"integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
+			"integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.4.4",
@@ -579,12 +579,12 @@
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.4.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
-			"integrity": "sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.0.tgz",
+			"integrity": "sha512-jem7uytlmrRl3iCAuQyw8BpB4c4LWvSpvIeXKpMb+7j84lkx4m4mYr5ErAcmN5KM7B6BqrAvRGjBIbbzqCczew==",
 			"dev": true,
 			"requires": {
-				"regexp-tree": "^0.1.6"
+				"regexp-tree": "^0.1.13"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
@@ -656,9 +656,9 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.5.5.tgz",
-			"integrity": "sha512-6Xmeidsun5rkwnGfMOp6/z9nSzWpHFNVr2Jx7kwoq4mVatQfQx5S56drBgEHF+XQbKOdIaOiMIINvp/kAwMN+w==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.0.tgz",
+			"integrity": "sha512-Da8tMf7uClzwUm/pnJ1S93m/aRXmoYNDD7TkHua8xBDdaAs54uZpTWvEt6NGwmoVMb9mZbntfTqmG2oSzN/7Vg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -726,9 +726,9 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.5.tgz",
-			"integrity": "sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.0.tgz",
+			"integrity": "sha512-1efzxFv/TcPsNXlRhMzRnkBFMeIqBBgzwmZwlFDw5Ubj0AGLeufxugirwZmkkX/ayi3owsSqoQ4fw8LkfK9SYg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -747,10 +747,10 @@
 				"@babel/plugin-transform-arrow-functions": "^7.2.0",
 				"@babel/plugin-transform-async-to-generator": "^7.5.0",
 				"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-				"@babel/plugin-transform-block-scoping": "^7.5.5",
+				"@babel/plugin-transform-block-scoping": "^7.6.0",
 				"@babel/plugin-transform-classes": "^7.5.5",
 				"@babel/plugin-transform-computed-properties": "^7.2.0",
-				"@babel/plugin-transform-destructuring": "^7.5.0",
+				"@babel/plugin-transform-destructuring": "^7.6.0",
 				"@babel/plugin-transform-dotall-regex": "^7.4.4",
 				"@babel/plugin-transform-duplicate-keys": "^7.5.0",
 				"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
@@ -759,10 +759,10 @@
 				"@babel/plugin-transform-literals": "^7.2.0",
 				"@babel/plugin-transform-member-expression-literals": "^7.2.0",
 				"@babel/plugin-transform-modules-amd": "^7.5.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.5.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.6.0",
 				"@babel/plugin-transform-modules-systemjs": "^7.5.0",
 				"@babel/plugin-transform-modules-umd": "^7.2.0",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.6.0",
 				"@babel/plugin-transform-new-target": "^7.4.4",
 				"@babel/plugin-transform-object-super": "^7.5.5",
 				"@babel/plugin-transform-parameters": "^7.4.4",
@@ -775,7 +775,7 @@
 				"@babel/plugin-transform-template-literals": "^7.4.4",
 				"@babel/plugin-transform-typeof-symbol": "^7.2.0",
 				"@babel/plugin-transform-unicode-regex": "^7.4.4",
-				"@babel/types": "^7.5.5",
+				"@babel/types": "^7.6.0",
 				"browserslist": "^4.6.0",
 				"core-js-compat": "^3.1.1",
 				"invariant": "^2.2.2",
@@ -784,46 +784,46 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
-			"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
+			"integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
 			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
 		"@babel/template": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-			"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+			"integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.4.4",
-				"@babel/types": "^7.4.4"
+				"@babel/parser": "^7.6.0",
+				"@babel/types": "^7.6.0"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-			"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.0.tgz",
+			"integrity": "sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.5.5",
+				"@babel/generator": "^7.6.0",
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-split-export-declaration": "^7.4.4",
-				"@babel/parser": "^7.5.5",
-				"@babel/types": "^7.5.5",
+				"@babel/parser": "^7.6.0",
+				"@babel/types": "^7.6.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/types": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-			"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
+			"integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
@@ -842,9 +842,9 @@
 			}
 		},
 		"@hapi/address": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
-			"integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.1.tgz",
+			"integrity": "sha512-DYuHzu978pP1XW1GD3HGvLnAFjbQTIgc2+V153FGkbS2pgo9haigCdwBnUDrbhaOkgiJlbZvoEqDrcxSLHpiWA==",
 			"dev": true
 		},
 		"@hapi/bourne": {
@@ -854,9 +854,9 @@
 			"dev": true
 		},
 		"@hapi/hoek": {
-			"version": "8.2.1",
-			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.1.tgz",
-			"integrity": "sha512-JPiBy+oSmsq3St7XlipfN5pNA6bDJ1kpa73PrK/zR29CVClDVqy04AanM/M/qx5bSF+I61DdCfAvRrujau+zRg==",
+			"version": "8.2.4",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.4.tgz",
+			"integrity": "sha512-Ze5SDNt325yZvNO7s5C4fXDscjJ6dcqLFXJQ/M7dZRQCewuDj2iDUuBi6jLQt+APbW9RjjVEvLr35FXuOEqjow==",
 			"dev": true
 		},
 		"@hapi/joi": {
@@ -1120,9 +1120,9 @@
 			"dev": true
 		},
 		"@types/babel__core": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
-			"integrity": "sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
+			"integrity": "sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -1215,9 +1215,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "12.7.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz",
-			"integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==",
+			"version": "12.7.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
+			"integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==",
 			"dev": true
 		},
 		"@types/stack-utils": {
@@ -1263,9 +1263,9 @@
 			}
 		},
 		"@types/yargs-parser": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.0.0.tgz",
-			"integrity": "sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==",
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
+			"integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
 			"dev": true
 		},
 		"@typescript-eslint/experimental-utils": {
@@ -1539,9 +1539,9 @@
 			"dev": true
 		},
 		"@wordpress/babel-preset-default": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.5.0.tgz",
-			"integrity": "sha512-LkRtmVAsFP/litK323Y6Yk1/3GujyhBykToG3iCPbRoA4elGybCaj9AqXgSS1gIxxRYOTFf8Gt0LaF+xShIGuQ==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.6.0.tgz",
+			"integrity": "sha512-qx7sHrhsdb5NOHxXFDoTgKU2G8zCB+fBO2PZdkF5x+6PRdqfvbiJ1i848qcMARSqhwY7tHB3R7KOPLZGHbq2hw==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.4.4",
@@ -1553,7 +1553,7 @@
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/babel-plugin-import-jsx-pragma": "^2.3.0",
 				"@wordpress/browserslist-config": "^2.6.0",
-				"@wordpress/element": "^2.7.0",
+				"@wordpress/element": "^2.8.0",
 				"core-js": "^3.1.4"
 			},
 			"dependencies": {
@@ -1572,22 +1572,22 @@
 			"dev": true
 		},
 		"@wordpress/components": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.2.0.tgz",
-			"integrity": "sha512-fde8bKDNcn9fhq48Mj2QyaTjrluYBK8A77P+MGmiU/x72FtMvj8/HdBOoDpmuGMApTc5oDAfAzNiYyDHIHzNqQ==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.3.0.tgz",
+			"integrity": "sha512-Q+eo3+RoViIDmDL4QhxpcTeCYYNAD6fVtNjHsI0hIQI7BVicZAqwApFColA7lxx1Y4/WTIcPHi/2h+WBlUxeLg==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/a11y": "^2.5.0",
-				"@wordpress/compose": "^3.6.0",
+				"@wordpress/compose": "^3.7.0",
 				"@wordpress/deprecated": "^2.6.0",
 				"@wordpress/dom": "^2.5.0",
-				"@wordpress/element": "^2.7.0",
+				"@wordpress/element": "^2.8.0",
 				"@wordpress/hooks": "^2.6.0",
 				"@wordpress/i18n": "^3.6.0",
 				"@wordpress/is-shallow-equal": "^1.6.0",
 				"@wordpress/keycodes": "^2.6.0",
-				"@wordpress/rich-text": "^3.6.0",
+				"@wordpress/rich-text": "^3.7.0",
 				"classnames": "^2.2.5",
 				"clipboard": "^2.0.1",
 				"dom-scroll-into-view": "^1.2.1",
@@ -1604,27 +1604,27 @@
 			}
 		},
 		"@wordpress/compose": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.6.0.tgz",
-			"integrity": "sha512-ixXGsj2aBizA4XiawR0n8+Ee2vmhmyGkd9Cy4LZs4aQFunDVXuVypxk74YQJstzJCUVMdvR8B5K8vrnh38QDFw==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.7.0.tgz",
+			"integrity": "sha512-DxwRCico4wVm8YnARaO7bZhcV6SoIjhVoNF7IPMvPnOXKfvp/w6QfcDl0qCtRqpofgZBCs93mRhFXHywQE0N6g==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/element": "^2.7.0",
+				"@wordpress/element": "^2.8.0",
 				"@wordpress/is-shallow-equal": "^1.6.0",
 				"lodash": "^4.17.14"
 			}
 		},
 		"@wordpress/data": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.8.0.tgz",
-			"integrity": "sha512-WUdE6C7CfG6gcQw2nZ+VQ3EAB5alga97BjqTdvuAAm6BLFLwd5LDn4maQYLPFrQp27CyzjDy6KzKARHDrUJBOg==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.9.0.tgz",
+			"integrity": "sha512-wlaIXPU+vcKK+hoTsUMxdxU0WHlGSuqhJMmkLabNY5B/UTapajaeYROrFZ0Co/zS6eqgU5mXfqyVOam3/GDI9A==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/compose": "^3.6.0",
+				"@wordpress/compose": "^3.7.0",
 				"@wordpress/deprecated": "^2.6.0",
-				"@wordpress/element": "^2.7.0",
+				"@wordpress/element": "^2.8.0",
 				"@wordpress/is-shallow-equal": "^1.6.0",
 				"@wordpress/priority-queue": "^1.3.0",
 				"@wordpress/redux-routine": "^3.6.0",
@@ -1636,11 +1636,12 @@
 			}
 		},
 		"@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-1.2.0.tgz",
-			"integrity": "sha512-+x0ID9r1cyXMCAoN8leM0Eo5IJ/iFW4+4y323dLcksP6PBoY78f8sJeSwTH058Ts9en7wvsRc8pdOza/gZHVpw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-2.0.0.tgz",
+			"integrity": "sha512-RJSbpnLBndYu02jrzbk0MTUi4uoOiEHXYSe9s8YM/40yJnUm6k1PvrytDG6VxFbjFARCCOzKgU70L+/xeC4pLQ==",
 			"dev": true,
 			"requires": {
+				"json2php": "^0.0.4",
 				"webpack": "^4.8.3",
 				"webpack-sources": "^1.3.0"
 			}
@@ -1675,16 +1676,16 @@
 			}
 		},
 		"@wordpress/element": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.7.0.tgz",
-			"integrity": "sha512-wyGOSFucslwndsSU4VlO7Z67C4NszsESM21fDwLF3z/JUcZDbcTZLmEId2QysgYUYtX5sBk6OvoTe8f4FY+SKQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.8.0.tgz",
+			"integrity": "sha512-fjFKf4h6dxjlTW4HKp+UNcCQDQaUGFLwjK6hMmet5YhklYvyg/+3bvDx1qqxe1BbY7kYvVhzVmldhJctOKPglQ==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/escape-html": "^1.5.0",
 				"lodash": "^4.17.14",
-				"react": "^16.8.4",
-				"react-dom": "^16.8.4"
+				"react": "^16.9.0",
+				"react-dom": "^16.9.0"
 			}
 		},
 		"@wordpress/escape-html": {
@@ -1697,9 +1698,9 @@
 			}
 		},
 		"@wordpress/eslint-plugin": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-3.0.0.tgz",
-			"integrity": "sha512-/X3hDwIgtPLp4niG+1S+QqKSgYBhYNjyZUB6W2k8ytsd0Z+WAKDN4hIbJ8/UY8XNVs+marhlJpgxfhlVLP/4ig==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-3.1.0.tgz",
+			"integrity": "sha512-i/eNTWll3OH7rFukG2pNZXlOl0xihnuxg/2maEEMGzLS8dA8TEwyzCUXCqKycpOLR9sqODhdWFjeQBAPIjpZHg==",
 			"dev": true,
 			"requires": {
 				"babel-eslint": "^10.0.2",
@@ -1713,9 +1714,9 @@
 			},
 			"dependencies": {
 				"globals": {
-					"version": "12.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.0.0.tgz",
-					"integrity": "sha512-c9xoi32iDwlETiyYfO0pd3M8GcEuytJinSoqq7k3fz4H8p2p31NyfKr7JVd7Y0QvmtWcWXcwqW4L33eeDYgh1A==",
+					"version": "12.1.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-12.1.0.tgz",
+					"integrity": "sha512-GQ4xcAfbMWx/Lly8PUHIn8/t2o7YEoMWnQ7nhJtjEJ1gs8I4Y+koc0GiraVMaSjc9Ghz99obkMau/tSK/ACEsQ==",
 					"dev": true,
 					"requires": {
 						"type-fest": "^0.6.0"
@@ -1767,9 +1768,9 @@
 			}
 		},
 		"@wordpress/jest-preset-default": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-5.0.0.tgz",
-			"integrity": "sha512-+I84XwTC+aRq2W6R6XeCCK7DFVUrNq/WzyzmhsFvfE4Kbb3+LJzhMUhpzNLTtZztZaBbDN/374xpeyEEZTNClw==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-5.1.0.tgz",
+			"integrity": "sha512-BqUkdxlE2RpLwQ+I9O5Tt5RrrxShfLK8Q3cooK+gjOv7ycaD81qkngwIx9oRdSf9iscFkVIAhRiVTNnNba9Hjg==",
 			"dev": true,
 			"requires": {
 				"@wordpress/jest-console": "^3.3.0",
@@ -1818,15 +1819,16 @@
 			}
 		},
 		"@wordpress/rich-text": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.6.0.tgz",
-			"integrity": "sha512-DbiCo1Cypkz9EJ38eGvoNpM/tDTRZYrCNYSDRhNHAK6zODUqTB9L6+tGVdpUQSTjsgoFUBoVeqAAM3hIvcTjgQ==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.7.0.tgz",
+			"integrity": "sha512-/A84zW0yaBSKM3p/QiDX+6AKmDbOFmjXWuO0gdQkV5ZdECORfB0yu/gR72hcNSWsm1DjVa2Mn7AbLkbFVkCJ8w==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/compose": "^3.6.0",
-				"@wordpress/data": "^4.8.0",
-				"@wordpress/element": "^2.7.0",
+				"@wordpress/compose": "^3.7.0",
+				"@wordpress/data": "^4.9.0",
+				"@wordpress/deprecated": "^2.6.0",
+				"@wordpress/element": "^2.8.0",
 				"@wordpress/escape-html": "^1.5.0",
 				"@wordpress/hooks": "^2.6.0",
 				"@wordpress/is-shallow-equal": "^1.6.0",
@@ -1838,30 +1840,36 @@
 			}
 		},
 		"@wordpress/scripts": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-4.0.0.tgz",
-			"integrity": "sha512-OS0gIL2lfEcegZq6sl7kaZUhViYYhA/Ulb1BR53w31az/n/FdcHJi/EfxFXMWIsVE9CmEgU3r8bTXB6vwjnedg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-5.0.0.tgz",
+			"integrity": "sha512-pidfRYMyG8RBwLLGto6VuMgeOrnfI/Ah/e4IBhvnLLMZOq1KW1mT8Am1k9idrMSnab0cmhOuNVQ2qifk/DR1aA==",
 			"dev": true,
 			"requires": {
-				"@wordpress/babel-preset-default": "^4.5.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^1.2.0",
-				"@wordpress/eslint-plugin": "^3.0.0",
-				"@wordpress/jest-preset-default": "^5.0.0",
+				"@wordpress/babel-preset-default": "^4.6.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^2.0.0",
+				"@wordpress/eslint-plugin": "^3.1.0",
+				"@wordpress/jest-preset-default": "^5.1.0",
 				"@wordpress/npm-package-json-lint-config": "^2.1.0",
 				"babel-jest": "^24.7.1",
 				"babel-loader": "^8.0.5",
 				"chalk": "^2.4.1",
 				"check-node-version": "^3.1.1",
+				"command-exists": "1.2.8",
 				"cross-spawn": "^5.1.0",
+				"decompress-zip": "0.2.2",
 				"eslint": "^6.1.0",
 				"jest": "^24.7.1",
 				"jest-puppeteer": "^4.3.0",
+				"js-yaml": "3.13.1",
+				"lodash": "^4.17.14",
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^3.6.0",
 				"puppeteer": "^1.19.0",
 				"read-pkg-up": "^1.0.1",
+				"request": "2.88.0",
 				"resolve-bin": "^0.4.0",
 				"source-map-loader": "^0.2.4",
+				"sprintf-js": "^1.1.1",
 				"stylelint": "^9.10.1",
 				"stylelint-config-wordpress": "^13.1.0",
 				"thread-loader": "^2.1.2",
@@ -1875,6 +1883,12 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.1.tgz",
 			"integrity": "sha512-1zSbbCuoIjafKZ3mblY5ikvAb0ODUbqBnFuUb7f6uLeQhhGJ0vEV4ntmtxKLT2WgXCO94E07BjunsIw1jOMPZw==",
+			"dev": true
+		},
+		"abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 			"dev": true
 		},
 		"accepts": {
@@ -1903,9 +1917,9 @@
 			}
 		},
 		"acorn-globals": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.3.tgz",
-			"integrity": "sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+			"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
 			"dev": true,
 			"requires": {
 				"acorn": "^6.0.1",
@@ -2613,6 +2627,16 @@
 			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
 			"dev": true
 		},
+		"binary": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+			"integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+			"dev": true,
+			"requires": {
+				"buffers": "~0.1.1",
+				"chainsaw": "~0.1.0"
+			}
+		},
 		"binary-extensions": {
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -2860,14 +2884,14 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.6.6",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
-			"integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
+			"integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30000984",
-				"electron-to-chromium": "^1.3.191",
-				"node-releases": "^1.1.25"
+				"caniuse-lite": "^1.0.30000989",
+				"electron-to-chromium": "^1.3.247",
+				"node-releases": "^1.1.29"
 			}
 		},
 		"bser": {
@@ -2900,6 +2924,12 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
 			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+			"dev": true
+		},
+		"buffers": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
 			"dev": true
 		},
 		"builtin-status-codes": {
@@ -3041,6 +3071,15 @@
 			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
 			"integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==",
 			"dev": true
+		},
+		"chainsaw": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+			"integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+			"dev": true,
+			"requires": {
+				"traverse": ">=0.3.0 <0.4"
+			}
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -3324,6 +3363,12 @@
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
+		},
+		"command-exists": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
+			"integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==",
+			"dev": true
 		},
 		"commander": {
 			"version": "2.13.0",
@@ -3652,9 +3697,9 @@
 			}
 		},
 		"cyclist": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
+			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
 			"dev": true
 		},
 		"damerau-levenshtein": {
@@ -3740,6 +3785,47 @@
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
+		},
+		"decompress-zip": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.2.2.tgz",
+			"integrity": "sha512-v+Na3Ck86Px7s2ix+f77pMQC3GlkxHHN+YyvnkEW7+xX5F39pcDpIV/VFvGYk8MznTFcMoPjL3XNWEJLXWoSPw==",
+			"dev": true,
+			"requires": {
+				"binary": "^0.3.0",
+				"graceful-fs": "^4.1.3",
+				"mkpath": "^0.1.0",
+				"nopt": "^3.0.1",
+				"q": "^1.1.2",
+				"readable-stream": "^1.1.8",
+				"touch": "0.0.3"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				}
+			}
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -4005,21 +4091,21 @@
 			"dev": true
 		},
 		"ejs": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz",
-			"integrity": "sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.1.tgz",
+			"integrity": "sha512-kS/gEPzZs3Y1rRsbGX4UOSjtP/CeJP0CxSNZHYxGfVM/VgLcv0ZqM7C45YyTj2DI2g7+P9Dd24C+IMIg6D0nYQ==",
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.244",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.244.tgz",
-			"integrity": "sha512-nEfPd2EKnFeLuZ/+JsRG3KixRQwWf2SPpp09ftNt5ouGhg408N759+oXvdXy57+TcM34ykfJYj2JMkc1O3R0lQ==",
+			"version": "1.3.260",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.260.tgz",
+			"integrity": "sha512-wGt+OivF1C1MPwaSv3LJ96ebNbLAWlx3HndivDDWqwIVSQxmhL17Y/YmwUdEMtS/bPyommELt47Dct0/VZNQBQ==",
 			"dev": true
 		},
 		"elliptic": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
-			"integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
+			"integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
 			"dev": true,
 			"requires": {
 				"bn.js": "^4.4.0",
@@ -4168,13 +4254,12 @@
 			}
 		},
 		"error": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
-			"integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/error/-/error-7.2.0.tgz",
+			"integrity": "sha512-M6t3j3Vt3uDicrViMP5fLq2AeADNrCVFD8Oj4Qt2MHsX0mPYG7D5XdnEfSdRpaHQzjAJ19wu+I1mw9rQYMTAPg==",
 			"dev": true,
 			"requires": {
-				"string-template": "~0.2.1",
-				"xtend": "~4.0.0"
+				"string-template": "~0.2.1"
 			}
 		},
 		"error-ex": {
@@ -4187,17 +4272,21 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+			"version": "1.14.2",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
+			"integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.0",
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
+				"has-symbols": "^1.0.0",
 				"is-callable": "^1.1.4",
 				"is-regex": "^1.0.4",
-				"object-keys": "^1.0.12"
+				"object-inspect": "^1.6.0",
+				"object-keys": "^1.1.1",
+				"string.prototype.trimleft": "^2.0.0",
+				"string.prototype.trimright": "^2.0.0"
 			}
 		},
 		"es-to-primitive": {
@@ -4267,9 +4356,9 @@
 			}
 		},
 		"eslint": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.2.2.tgz",
-			"integrity": "sha512-mf0elOkxHbdyGX1IJEUsNBzCDdyoUgljF3rRlgfyYh0pwGnreLc0jjD6ZuleOibjmnUWZLY2eXwSooeOgGJ2jw==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.4.0.tgz",
+			"integrity": "sha512-WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
@@ -4369,18 +4458,18 @@
 			}
 		},
 		"eslint-plugin-jest": {
-			"version": "22.15.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.15.2.tgz",
-			"integrity": "sha512-p4NME9TgXIt+KgpxcXyNBvO30ZKxwFAO1dJZBc2OGfDnXVEtPwEyNs95GSr6RIE3xLHdjd8ngDdE2icRRXrbxg==",
+			"version": "22.17.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.17.0.tgz",
+			"integrity": "sha512-WT4DP4RoGBhIQjv+5D0FM20fAdAUstfYAf/mkufLNTojsfgzc5/IYW22cIg/Q4QBavAZsROQlqppiWDpFZDS8Q==",
 			"dev": true,
 			"requires": {
 				"@typescript-eslint/experimental-utils": "^1.13.0"
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "15.8.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-15.8.3.tgz",
-			"integrity": "sha512-p2O6SYetuSD5gWV04HHevIfp2WfimXReYwINuB4iC33hm1jrYoP+t2XbJtCBYvjhoRjjw8w4NfnyZKixte1fug==",
+			"version": "15.9.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-15.9.2.tgz",
+			"integrity": "sha512-dJjIWFJlh4ti3CegWYN0jUUdjEsWvJ8TZJ/cMQldioVLxMmU3UZeZsHzxYcCicJwSVhQ+uGm+dbUyEIm0slX3Q==",
 			"dev": true,
 			"requires": {
 				"comment-parser": "^0.6.2",
@@ -6100,9 +6189,9 @@
 			}
 		},
 		"handlebars": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
+			"integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
 			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",
@@ -7669,6 +7758,12 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
 		},
+		"json2php": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/json2php/-/json2php-0.0.4.tgz",
+			"integrity": "sha1-a9haHdpqXdfpECK7JEA8wbfC7jQ=",
+			"dev": true
+		},
 		"json5": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
@@ -8115,9 +8210,9 @@
 			"dev": true
 		},
 		"merge2": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",
-			"integrity": "sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
 			"dev": true
 		},
 		"methods": {
@@ -8295,6 +8390,12 @@
 				}
 			}
 		},
+		"mkpath": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+			"integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE=",
+			"dev": true
+		},
 		"moment": {
 			"version": "2.24.0",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
@@ -8372,9 +8473,9 @@
 			"dev": true
 		},
 		"nearley": {
-			"version": "2.18.0",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.18.0.tgz",
-			"integrity": "sha512-/zQOMCeJcioI0xJtd5RpBiWw2WP7wLe6vq8/3Yu0rEwgus/G/+pViX80oA87JdVgjRt2895mZSv2VfZmy4W1uw==",
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.0.tgz",
+			"integrity": "sha512-2v52FTw7RPqieZr3Gth1luAXZR7Je6q3KaDHY5bjl/paDUdMu35fZ8ICNgiYJRr3tf3NMvIQQR1r27AvEr9CRA==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
@@ -8485,12 +8586,21 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.28",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.28.tgz",
-			"integrity": "sha512-AQw4emh6iSXnCpDiFe0phYcThiccmkNWMZnFZ+lDJjAP8J0m2fVd59duvUUyuTirQOhIAajTFkzG6FHCLBO59g==",
+			"version": "1.1.32",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.32.tgz",
+			"integrity": "sha512-VhVknkitq8dqtWoluagsGPn3dxTvN9fwgR59fV3D7sLBHe0JfDramsMI8n8mY//ccq/Kkrf8ZRHRpsyVZ3qw1A==",
 			"dev": true,
 			"requires": {
 				"semver": "^5.3.0"
+			}
+		},
+		"nopt": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+			"dev": true,
+			"requires": {
+				"abbrev": "1"
 			}
 		},
 		"normalize-package-data": {
@@ -8901,12 +9011,12 @@
 			"dev": true
 		},
 		"parallel-transform": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
+			"integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
 			"dev": true,
 			"requires": {
-				"cyclist": "~0.2.2",
+				"cyclist": "^1.0.1",
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.1.5"
 			}
@@ -9122,9 +9232,9 @@
 			"dev": true
 		},
 		"portfinder": {
-			"version": "1.0.23",
-			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.23.tgz",
-			"integrity": "sha512-B729mL/uLklxtxuiJKfQ84WPxNw5a7Yhx3geQZdcA4GjNjZSTSSMMWyoennMVnTWSmAR0lMdzWYN0JLnHrg1KQ==",
+			"version": "1.0.24",
+			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.24.tgz",
+			"integrity": "sha512-ekRl7zD2qxYndYflwiryJwMioBI7LI7rVXg3EnLK3sjkouT5eOuhS3gS255XxBksa30VG8UPZYZCdgfGOfkSUg==",
 			"dev": true,
 			"requires": {
 				"async": "^1.5.2",
@@ -9162,9 +9272,9 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "7.0.17",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-			"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
+			"version": "7.0.18",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
+			"integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
@@ -9419,9 +9529,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
-			"integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+			"integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
 			"dev": true
 		},
 		"public-encrypt": {
@@ -9466,9 +9576,9 @@
 			"dev": true
 		},
 		"puppeteer": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.19.0.tgz",
-			"integrity": "sha512-2S6E6ygpoqcECaagDbBopoSOPDv0pAZvTbnBgUY+6hq0/XDFDOLEMNlHF/SKJlzcaZ9ckiKjKDuueWI3FN/WXw==",
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.20.0.tgz",
+			"integrity": "sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.1.0",
@@ -9491,6 +9601,12 @@
 					}
 				}
 			}
+		},
+		"q": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+			"dev": true
 		},
 		"qs": {
 			"version": "6.5.2",
@@ -9701,27 +9817,19 @@
 			}
 		},
 		"react-with-direction": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.3.0.tgz",
-			"integrity": "sha512-2TflEebNckTNUybw3Rzqjg4BwM/H380ZL5lsbZ5f4UTY2JyE5uQdQZK5T2w+BDJSAMcqoA2RDJYa4e7Cl6C2Kg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.3.1.tgz",
+			"integrity": "sha512-aGcM21ZzhqeXFvDCfPj0rVNYuaVXfTz5D3Rbn0QMz/unZe+CCiLHthrjQWO7s6qdfXORgYFtmS7OVsRgSk5LXQ==",
 			"dev": true,
 			"requires": {
-				"airbnb-prop-types": "^2.8.1",
+				"airbnb-prop-types": "^2.10.0",
 				"brcast": "^2.0.2",
-				"deepmerge": "^1.5.1",
-				"direction": "^1.0.1",
-				"hoist-non-react-statics": "^2.3.1",
+				"deepmerge": "^1.5.2",
+				"direction": "^1.0.2",
+				"hoist-non-react-statics": "^3.3.0",
 				"object.assign": "^4.1.0",
 				"object.values": "^1.0.4",
-				"prop-types": "^15.6.0"
-			},
-			"dependencies": {
-				"hoist-non-react-statics": {
-					"version": "2.5.5",
-					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-					"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
-					"dev": true
-				}
+				"prop-types": "^15.6.2"
 			}
 		},
 		"react-with-styles": {
@@ -9957,9 +10065,9 @@
 			}
 		},
 		"regexp-tree": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.12.tgz",
-			"integrity": "sha512-TsXZ8+cv2uxMEkLfgwO0E068gsNMLfuYwMMhiUxf0Kw2Vcgzq93vgl6wIlIYuPmfMqMjfQ9zAporiozqCnwLuQ==",
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.13.tgz",
+			"integrity": "sha512-hwdV/GQY5F8ReLZWO+W1SRoN5YfpOKY6852+tBFcma72DKBIcHjPRIlIvQN35bCOljuAfP2G2iB0FC/w236mUw==",
 			"dev": true
 		},
 		"regexpp": {
@@ -9969,9 +10077,9 @@
 			"dev": true
 		},
 		"regexpu-core": {
-			"version": "4.5.5",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
-			"integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+			"integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
 			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0",
@@ -10326,9 +10434,9 @@
 			"dev": true
 		},
 		"rxjs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
-			"integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+			"integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
@@ -10469,9 +10577,9 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.0.tgz",
-			"integrity": "sha512-UkGlcYMtw4d9w7YfCtJFgdRTps8N4L0A48R+SmcGL57ki1+yHwJXnalk5bjgrw+ljv6SfzjzPjhohod2qllg/Q==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
+			"integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
 			"dev": true
 		},
 		"serve-static": {
@@ -11043,6 +11151,26 @@
 				"function-bind": "^1.1.1"
 			}
 		},
+		"string.prototype.trimleft": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+			"integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
+			}
+		},
+		"string.prototype.trimright": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+			"integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
+			}
+		},
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -11253,9 +11381,9 @@
 			}
 		},
 		"stylelint-scss": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.10.0.tgz",
-			"integrity": "sha512-cz0CiJ/CEOY9arl1OA7Epb68F+L5iXBVZSOzTdK5AymoTM5dpll4QGeggMIsKN5Put8ZtQ3OwzYXexkPKs15PQ==",
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.11.0.tgz",
+			"integrity": "sha512-2rA9hV8+ebvzGyRBQt/KCLDS1o11SEVRzOBlhAbqk4u1PVnWcjUhRhKIGGGWcyM4QE9t+YWivbnq6kjdeHg2Nw==",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.15",
@@ -11587,6 +11715,26 @@
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
 			"dev": true
 		},
+		"touch": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+			"integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
+			"dev": true,
+			"requires": {
+				"nopt": "~1.0.10"
+			},
+			"dependencies": {
+				"nopt": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+					"integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+					"dev": true,
+					"requires": {
+						"abbrev": "1"
+					}
+				}
+			}
+		},
 		"tough-cookie": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -11605,6 +11753,12 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
+		},
+		"traverse": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+			"dev": true
 		},
 		"tree-kill": {
 			"version": "1.2.1",
@@ -11945,9 +12099,9 @@
 			}
 		},
 		"upath": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
-			"integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
 			"dev": true
 		},
 		"uri-js": {
@@ -12282,9 +12436,9 @@
 			}
 		},
 		"webpack-bundle-analyzer": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.4.1.tgz",
-			"integrity": "sha512-Bs8D/1zF+17lhqj2OYmzi7HEVYqEVxu7lCO9Ff8BwajenOU0vAwEoV8e4ICCPNZAcqR1PCR/7o2SkW+cnCmF0A==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.5.0.tgz",
+			"integrity": "sha512-NzueflueLSJxWGzDlMq5oUV+P8Qoq6yiaQlXGCbDYUpHEKlmzWdPLBJ4k/B6HTdAP/vHM8ply1Fx08mDnY+S8Q==",
 			"dev": true,
 			"requires": {
 				"acorn": "^6.0.7",
@@ -12326,9 +12480,9 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "3.3.7",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.7.tgz",
-			"integrity": "sha512-OhTUCttAsr+IZSMVwGROGRHvT+QAs8H6/mHIl4SvhAwYywjiylYjpwybGx7WQ9Hkb45FhjtsymkwiRRbGJ1SZQ==",
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.9.tgz",
+			"integrity": "sha512-xwnSxWl8nZtBl/AFJCOn9pG7s5CYUYdZxmmukv+fAHLcBIHM36dImfpQg3WfShZXeArkWlf6QRw24Klcsv8a5A==",
 			"dev": true,
 			"requires": {
 				"chalk": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"build:05-recipe": "wp-scripts build 05-recipe-card-esnext/src/index.js --output-path=05-recipe-card-esnext/build"
 	},
 	"devDependencies": {
-		"@wordpress/components": "^8.1.0",
-		"@wordpress/scripts": "^3.4.0"
+		"@wordpress/components": "^8.2.0",
+		"@wordpress/scripts": "^4.0.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"build:05-recipe": "wp-scripts build 05-recipe-card-esnext/src/index.js --output-path=05-recipe-card-esnext/build"
 	},
 	"devDependencies": {
-		"@wordpress/components": "^8.2.0",
-		"@wordpress/scripts": "^4.0.0"
+		"@wordpress/components": "^8.3.0",
+		"@wordpress/scripts": "^5.0.0"
 	}
 }

--- a/test/examples.js
+++ b/test/examples.js
@@ -1,4 +1,3 @@
-/* global test, expect */
 /**
  * External dependencies
  */


### PR DESCRIPTION
`npm run lint-js` still doesn't work.

I'm seeing:

```
/Users/gziolo/PhpstormProjects/gutenberg-examples/test/examples.js
  12:1  error  'test' is not defined    no-undef
  17:2  error  'expect' is not defined  no-undef
  21:1  error  'test' is not defined    no-undef
  26:2  error  'expect' is not defined  no-undef

✖ 4 problems (4 errors, 0 warnings)
```