### PR TITLE
Clarify start instructions for development builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ To build the production version of the plugin
 npm run build
 ```
 
-To build a development version of the plugin and watch changes for automatic rebuild
+To build a development version, change to the local directory of the block you are working on, and run `npm start` to watch for changes and automatically rebuild as you develop. 
 ```
+cd 01-basic-esnext/
 npm start
 ```
 


### PR DESCRIPTION
Updates main readme for clarifying how to run a development build.
Requires switching to the individual block directory you are working on first.

Fixes #86 