### PR TITLE
Fix the ingredients tagName in the save to be the same as the edit.

### DIFF
--- a/05-recipe-card-esnext/src/index.js
+++ b/05-recipe-card-esnext/src/index.js
@@ -147,7 +147,7 @@ registerBlockType( 'gutenberg-examples/example-05-recipe-card-esnext', {
 					)
 				}
 
-				<RichText.Content tagName="h2" className="ingredients" value={ ingredients } />
+				<RichText.Content tagName="ul" className="ingredients" value={ ingredients } />
 
 				<RichText.Content tagName="div" className="steps" value={ instructions } />
 			</div>


### PR DESCRIPTION
In the `05-recipe-card-esnext` example, the ingredients `tagName` was `h2` in the save, while it is `ul` in the edit.