### PR TITLE
Chore: Update @wordpress/scripts to 9.0.0

### DIFF
--- a/01-basic-esnext/build/index.asset.php
+++ b/01-basic-esnext/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-i18n', 'wp-polyfill'), 'version' => '5a04950f23fc46f385beca6ef36cb5e8');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-i18n', 'wp-polyfill'), 'version' => 'a35cc1c098b69994c9c6d6dc1416bb90');

--- a/01-basic-esnext/package.json
+++ b/01-basic-esnext/package.json
@@ -16,12 +16,12 @@
 	},
 	"main": "build/index.js",
 	"devDependencies": {
-		"@wordpress/scripts": "^8.0.1"
+		"@wordpress/scripts": "^9.0.0"
 	},
 	"scripts": {
 		"build": "wp-scripts build",
 		"format:js": "wp-scripts format-js",
-		"lint:js": "wp-scripts lint-js --rule '@wordpress/i18n-text-domain: 0'",
+		"lint:js": "wp-scripts lint-js",
 		"packages-update": "wp-scripts packages-update",
 		"start": "wp-scripts start"
 	}

--- a/03-editable-esnext/build/index.asset.php
+++ b/03-editable-esnext/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-polyfill'), 'version' => 'b99976ae22787abf005d7e6ba3525ad3');
+<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-polyfill'), 'version' => 'ebd43150f92e5b16ea18cc759afffddc');

--- a/03-editable-esnext/package.json
+++ b/03-editable-esnext/package.json
@@ -16,12 +16,12 @@
 	},
 	"main": "build/index.js",
 	"devDependencies": {
-		"@wordpress/scripts": "^8.0.1"
+		"@wordpress/scripts": "^9.0.0"
 	},
 	"scripts": {
 		"build": "wp-scripts build",
 		"format:js": "wp-scripts format-js",
-		"lint:js": "wp-scripts lint-js --rule '@wordpress/i18n-text-domain: 0'",
+		"lint:js": "wp-scripts lint-js",
 		"packages-update": "wp-scripts packages-update",
 		"start": "wp-scripts start"
 	}

--- a/04-controls-esnext/build/index.asset.php
+++ b/04-controls-esnext/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-polyfill'), 'version' => 'ac7c55504e57d72fe1ae2414e860451e');
+<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-polyfill'), 'version' => '1308fa13597c9c273fa3727655254927');

--- a/04-controls-esnext/package.json
+++ b/04-controls-esnext/package.json
@@ -16,12 +16,12 @@
 	},
 	"main": "build/index.js",
 	"devDependencies": {
-		"@wordpress/scripts": "^8.0.1"
+		"@wordpress/scripts": "^9.0.0"
 	},
 	"scripts": {
 		"build": "wp-scripts build",
 		"format:js": "wp-scripts format-js",
-		"lint:js": "wp-scripts lint-js --rule '@wordpress/i18n-text-domain: 0'",
+		"lint:js": "wp-scripts lint-js",
 		"packages-update": "wp-scripts packages-update",
 		"start": "wp-scripts start"
 	}

--- a/05-recipe-card-esnext/build/index.asset.php
+++ b/05-recipe-card-esnext/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-components', 'wp-element', 'wp-i18n', 'wp-polyfill'), 'version' => '57dbc9959caae6278f001577a5f55f6a');
+<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-components', 'wp-element', 'wp-i18n', 'wp-polyfill'), 'version' => '2b0821ce0f4b62aefa95466fb32e752e');

--- a/05-recipe-card-esnext/package.json
+++ b/05-recipe-card-esnext/package.json
@@ -16,12 +16,12 @@
 	},
 	"main": "build/index.js",
 	"devDependencies": {
-		"@wordpress/scripts": "^8.0.1"
+		"@wordpress/scripts": "^9.0.0"
 	},
 	"scripts": {
 		"build": "wp-scripts build",
 		"format:js": "wp-scripts format-js",
-		"lint:js": "wp-scripts lint-js --rule '@wordpress/i18n-text-domain: 0'",
+		"lint:js": "wp-scripts lint-js",
 		"packages-update": "wp-scripts packages-update",
 		"start": "wp-scripts start"
 	}

--- a/06-inner-blocks-esnext/build/index.asset.php
+++ b/06-inner-blocks-esnext/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-element', 'wp-polyfill'), 'version' => '5f1cae70faf55bb006c00a28a9d2e3d6');
+<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-element', 'wp-polyfill'), 'version' => '3e3feaa0b42d475ad1dba41bcf282508');

--- a/06-inner-blocks-esnext/package.json
+++ b/06-inner-blocks-esnext/package.json
@@ -16,12 +16,12 @@
 	},
 	"main": "build/index.js",
 	"devDependencies": {
-		"@wordpress/scripts": "^8.0.1"
+		"@wordpress/scripts": "^9.0.0"
 	},
 	"scripts": {
 		"build": "wp-scripts build",
 		"format:js": "wp-scripts format-js",
-		"lint:js": "wp-scripts lint-js --rule '@wordpress/i18n-text-domain: 0'",
+		"lint:js": "wp-scripts lint-js",
 		"packages-update": "wp-scripts packages-update",
 		"start": "wp-scripts start"
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,30 +14,30 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.9.0.tgz",
-			"integrity": "sha512-zeFQrr+284Ekvd9e7KAX954LkapWiOmQtsfHirhxqfdlX6MEC32iRE+pqUGlYIBchdevaCwvzxWGSy/YBNI85g==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.9.6.tgz",
+			"integrity": "sha512-5QPTrNen2bm7RBc7dsOmcA5hbrS4O2Vhmk5XOL4zWW/zD/hV0iinpefDlkm+tBBy8kDtFaaeEvmAqt+nURAV2g==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.9.1",
+				"browserslist": "^4.11.1",
 				"invariant": "^2.2.4",
 				"semver": "^5.5.0"
 			}
 		},
 		"@babel/core": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
-			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.6.tgz",
+			"integrity": "sha512-nD3deLvbsApbHAHttzIssYqgb883yU/d9roe4RZymBCDaZryMJDbptVpEpeQuRh4BJ+SYI8le9YGxKvFEvl1Wg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.9.0",
+				"@babel/generator": "^7.9.6",
 				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helpers": "^7.9.0",
-				"@babel/parser": "^7.9.0",
+				"@babel/helpers": "^7.9.6",
+				"@babel/parser": "^7.9.6",
 				"@babel/template": "^7.8.6",
-				"@babel/traverse": "^7.9.0",
-				"@babel/types": "^7.9.0",
+				"@babel/traverse": "^7.9.6",
+				"@babel/types": "^7.9.6",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.1",
@@ -49,12 +49,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
-			"integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
+			"integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.9.5",
+				"@babel/types": "^7.9.6",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.13",
 				"source-map": "^0.5.0"
@@ -101,13 +101,13 @@
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.8.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.7.tgz",
-			"integrity": "sha512-4mWm8DCK2LugIS+p1yArqvG1Pf162upsIsjE7cNBjez+NjliQpVhj20obE520nao0o14DaTnFJv+Fw5a0JpoUw==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.9.6.tgz",
+			"integrity": "sha512-x2Nvu0igO0ejXzx09B/1fGBxY9NXQlBW2kZsSxCJft+KHN8t9XWzIvFxtPHnBOAXpVsdxZKZFbRUC8TsNKajMw==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.8.6",
-				"browserslist": "^4.9.1",
+				"@babel/compat-data": "^7.9.6",
+				"browserslist": "^4.11.1",
 				"invariant": "^2.2.4",
 				"levenary": "^1.1.1",
 				"semver": "^5.5.0"
@@ -245,15 +245,15 @@
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
-			"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.9.6.tgz",
+			"integrity": "sha512-qX+chbxkbArLyCImk3bWV+jB5gTNU/rsze+JlcF6Nf8tVTigPJSI1o1oBow/9Resa1yehUO9lIipsmu9oG4RzA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-member-expression-to-functions": "^7.8.3",
 				"@babel/helper-optimise-call-expression": "^7.8.3",
-				"@babel/traverse": "^7.8.6",
-				"@babel/types": "^7.8.6"
+				"@babel/traverse": "^7.9.6",
+				"@babel/types": "^7.9.6"
 			}
 		},
 		"@babel/helper-simple-access": {
@@ -294,14 +294,14 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
-			"integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.6.tgz",
+			"integrity": "sha512-tI4bUbldloLcHWoRUMAj4g1bF313M/o6fBKhIsb3QnGVPwRm9JsNf/gqMkQ7zjqReABiffPV6RWj7hEglID5Iw==",
 			"dev": true,
 			"requires": {
 				"@babel/template": "^7.8.3",
-				"@babel/traverse": "^7.9.0",
-				"@babel/types": "^7.9.0"
+				"@babel/traverse": "^7.9.6",
+				"@babel/types": "^7.9.6"
 			}
 		},
 		"@babel/highlight": {
@@ -316,9 +316,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.9.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
+			"integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
@@ -373,9 +373,9 @@
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.5.tgz",
-			"integrity": "sha512-VP2oXvAf7KCYTthbUHwBlewbl1Iq059f6seJGsxMizaCdgHIeczOr7FBqELhSqfkIl04Fi8okzWzl63UKbQmmg==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.6.tgz",
+			"integrity": "sha512-Ga6/fhGqA9Hj+y6whNpPv8psyaK5xzrQwSPsGPloVkvmH+PqW1ixdnfJ9uIO06OjQNYol3PMnfmJ8vfZtkzF+A==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3",
@@ -670,38 +670,38 @@
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.9.0.tgz",
-			"integrity": "sha512-vZgDDF003B14O8zJy0XXLnPH4sg+9X5hFBBGN1V+B2rgrB+J2xIypSN6Rk9imB2hSTHQi5OHLrFWsZab1GMk+Q==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.9.6.tgz",
+			"integrity": "sha512-zoT0kgC3EixAyIAU+9vfaUVKTv9IxBDSabgHoUCBP6FqEJ+iNiN7ip7NBKcYqbfUDfuC2mFCbM7vbu4qJgOnDw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.9.0",
 				"@babel/helper-plugin-utils": "^7.8.3",
-				"babel-plugin-dynamic-import-node": "^2.3.0"
+				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.0.tgz",
-			"integrity": "sha512-qzlCrLnKqio4SlgJ6FMMLBe4bySNis8DFn1VkGmOcxG9gqEyPIOzeQrA//u0HAKrWpJlpZbZMPB1n/OPa4+n8g==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.6.tgz",
+			"integrity": "sha512-7H25fSlLcn+iYimmsNe3uK1at79IE6SKW9q0/QeEHTMC9MdOZ+4bA+T1VFB5fgOqBWoqlifXRzYD0JPdmIrgSQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.9.0",
 				"@babel/helper-plugin-utils": "^7.8.3",
 				"@babel/helper-simple-access": "^7.8.3",
-				"babel-plugin-dynamic-import-node": "^2.3.0"
+				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.9.0.tgz",
-			"integrity": "sha512-FsiAv/nao/ud2ZWy4wFacoLOm5uxl0ExSQ7ErvP7jpoihLR6Cq90ilOFyX9UXct3rbtKsAiZ9kFt5XGfPe/5SQ==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.9.6.tgz",
+			"integrity": "sha512-NW5XQuW3N2tTHim8e1b7qGy7s0kZ2OH3m5octc49K1SdAKGxYxeIx7hiIz05kS1R2R+hOWcsr1eYwcGhrdHsrg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-hoist-variables": "^7.8.3",
 				"@babel/helper-module-transforms": "^7.9.0",
 				"@babel/helper-plugin-utils": "^7.8.3",
-				"babel-plugin-dynamic-import-node": "^2.3.0"
+				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
@@ -841,9 +841,9 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.9.0.tgz",
-			"integrity": "sha512-pUu9VSf3kI1OqbWINQ7MaugnitRss1z533436waNXp+0N3ur3zfut37sXiQMxkuCF4VUjwZucen/quskCh7NHw==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.9.6.tgz",
+			"integrity": "sha512-qcmiECD0mYOjOIt8YHNsAP1SxPooC/rDmfmiSK9BNY72EitdSc7l44WTEklaWuFtbOEBjNhWWyph/kOImbNJ4w==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.8.3",
@@ -910,13 +910,13 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.5.tgz",
-			"integrity": "sha512-eWGYeADTlPJH+wq1F0wNfPbVS1w1wtmMJiYk55Td5Yu28AsdR9AsC97sZ0Qq8fHqQuslVSIYSGJMcblr345GfQ==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.6.tgz",
+			"integrity": "sha512-0gQJ9RTzO0heXOhzftog+a/WyOuqMrAIugVYxMYf83gh1CQaQDjMtsOpqOwXyDL/5JcWsrCm8l4ju8QC97O7EQ==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.9.0",
-				"@babel/helper-compilation-targets": "^7.8.7",
+				"@babel/compat-data": "^7.9.6",
+				"@babel/helper-compilation-targets": "^7.9.6",
 				"@babel/helper-module-imports": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3",
 				"@babel/plugin-proposal-async-generator-functions": "^7.8.3",
@@ -924,7 +924,7 @@
 				"@babel/plugin-proposal-json-strings": "^7.8.3",
 				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
 				"@babel/plugin-proposal-numeric-separator": "^7.8.3",
-				"@babel/plugin-proposal-object-rest-spread": "^7.9.5",
+				"@babel/plugin-proposal-object-rest-spread": "^7.9.6",
 				"@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
 				"@babel/plugin-proposal-optional-chaining": "^7.9.0",
 				"@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
@@ -951,9 +951,9 @@
 				"@babel/plugin-transform-function-name": "^7.8.3",
 				"@babel/plugin-transform-literals": "^7.8.3",
 				"@babel/plugin-transform-member-expression-literals": "^7.8.3",
-				"@babel/plugin-transform-modules-amd": "^7.9.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.9.0",
-				"@babel/plugin-transform-modules-systemjs": "^7.9.0",
+				"@babel/plugin-transform-modules-amd": "^7.9.6",
+				"@babel/plugin-transform-modules-commonjs": "^7.9.6",
+				"@babel/plugin-transform-modules-systemjs": "^7.9.6",
 				"@babel/plugin-transform-modules-umd": "^7.9.0",
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
 				"@babel/plugin-transform-new-target": "^7.8.3",
@@ -969,8 +969,8 @@
 				"@babel/plugin-transform-typeof-symbol": "^7.8.4",
 				"@babel/plugin-transform-unicode-regex": "^7.8.3",
 				"@babel/preset-modules": "^0.1.3",
-				"@babel/types": "^7.9.5",
-				"browserslist": "^4.9.1",
+				"@babel/types": "^7.9.6",
+				"browserslist": "^4.11.1",
 				"core-js-compat": "^3.6.2",
 				"invariant": "^2.2.2",
 				"levenary": "^1.1.1",
@@ -1005,18 +1005,18 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+			"integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
 			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"@babel/runtime-corejs3": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
-			"integrity": "sha512-HHxmgxbIzOfFlZ+tdeRKtaxWOMUoCG5Mu3wKeUmOxjYrwb3AAHgnmtCUbPPK11/raIWLIBK250t8E2BPO0p7jA==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.6.tgz",
+			"integrity": "sha512-6toWAfaALQjt3KMZQc6fABqZwUDDuWzz+cAfPhqyEnzxvdWOAkjwPNxgF8xlmo7OWLsSjaKjsskpKHRLaMArOA==",
 			"dev": true,
 			"requires": {
 				"core-js-pure": "^3.0.0",
@@ -1035,26 +1035,26 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
-			"integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
+			"integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.9.5",
+				"@babel/generator": "^7.9.6",
 				"@babel/helper-function-name": "^7.9.5",
 				"@babel/helper-split-export-declaration": "^7.8.3",
-				"@babel/parser": "^7.9.0",
-				"@babel/types": "^7.9.5",
+				"@babel/parser": "^7.9.6",
+				"@babel/types": "^7.9.6",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/types": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-			"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+			"integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.9.5",
@@ -1425,14 +1425,15 @@
 			"dev": true
 		},
 		"@jest/console": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-25.3.0.tgz",
-			"integrity": "sha512-LvSDNqpmZIZyweFaEQ6wKY7CbexPitlsLHGJtcooNECo0An/w49rFhjCJzu6efeb6+a3ee946xss1Jcd9r03UQ==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-25.5.0.tgz",
+			"integrity": "sha512-T48kZa6MK1Y6k4b89sexwmSF4YLeZS/Udqg3Jj3jG/cHH+N/sLFCEoXEDMOKugJQ9FxPN1osxIknvKkxt6MKyw==",
 			"dev": true,
 			"requires": {
-				"@jest/source-map": "^25.2.6",
+				"@jest/types": "^25.5.0",
 				"chalk": "^3.0.0",
-				"jest-util": "^25.3.0",
+				"jest-message-util": "^25.5.0",
+				"jest-util": "^25.5.0",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
@@ -1495,33 +1496,33 @@
 			}
 		},
 		"@jest/core": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-25.3.0.tgz",
-			"integrity": "sha512-+D5a/tFf6pA/Gqft2DLBp/yeSRgXhlJ+Wpst0X/ZkfTRP54qDR3C61VfHwaex+GzZBiTcE9vQeoZ2v5T10+Mqw==",
+			"version": "25.5.2",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-25.5.2.tgz",
+			"integrity": "sha512-vc7WqwPbFX22EWDbuxJDnWDh5YYyReimgxKO/DYA1wMJd7/PcbUwM4PY7xadRZ2ze8Wi3OtmXP8ZbJEfcWY5Xg==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^25.3.0",
-				"@jest/reporters": "^25.3.0",
-				"@jest/test-result": "^25.3.0",
-				"@jest/transform": "^25.3.0",
-				"@jest/types": "^25.3.0",
+				"@jest/console": "^25.5.0",
+				"@jest/reporters": "^25.5.1",
+				"@jest/test-result": "^25.5.0",
+				"@jest/transform": "^25.5.1",
+				"@jest/types": "^25.5.0",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^3.0.0",
 				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.3",
-				"jest-changed-files": "^25.3.0",
-				"jest-config": "^25.3.0",
-				"jest-haste-map": "^25.3.0",
-				"jest-message-util": "^25.3.0",
+				"graceful-fs": "^4.2.4",
+				"jest-changed-files": "^25.5.0",
+				"jest-config": "^25.5.2",
+				"jest-haste-map": "^25.5.1",
+				"jest-message-util": "^25.5.0",
 				"jest-regex-util": "^25.2.6",
-				"jest-resolve": "^25.3.0",
-				"jest-resolve-dependencies": "^25.3.0",
-				"jest-runner": "^25.3.0",
-				"jest-runtime": "^25.3.0",
-				"jest-snapshot": "^25.3.0",
-				"jest-util": "^25.3.0",
-				"jest-validate": "^25.3.0",
-				"jest-watcher": "^25.3.0",
+				"jest-resolve": "^25.5.1",
+				"jest-resolve-dependencies": "^25.5.2",
+				"jest-runner": "^25.5.2",
+				"jest-runtime": "^25.5.2",
+				"jest-snapshot": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"jest-validate": "^25.5.0",
+				"jest-watcher": "^25.5.0",
 				"micromatch": "^4.0.2",
 				"p-each-series": "^2.1.0",
 				"realpath-native": "^2.0.0",
@@ -1588,6 +1589,12 @@
 					"requires": {
 						"to-regex-range": "^5.0.1"
 					}
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
 				},
 				"has-flag": {
 					"version": "4.0.0",
@@ -1656,59 +1663,71 @@
 			}
 		},
 		"@jest/environment": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.3.0.tgz",
-			"integrity": "sha512-vgooqwJTHLLak4fE+TaCGeYP7Tz1Y3CKOsNxR1sE0V3nx3KRUHn3NUnt+wbcfd5yQWKZQKAfW6wqbuwQLrXo3g==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.5.0.tgz",
+			"integrity": "sha512-U2VXPEqL07E/V7pSZMSQCvV5Ea4lqOlT+0ZFijl/i316cRMHvZ4qC+jBdryd+lmRetjQo0YIQr6cVPNxxK87mA==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "^25.3.0",
-				"@jest/types": "^25.3.0",
-				"jest-mock": "^25.3.0"
+				"@jest/fake-timers": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"jest-mock": "^25.5.0"
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.3.0.tgz",
-			"integrity": "sha512-NHAj7WbsyR3qBJPpBwSwqaq2WluIvUQsyzpJTN7XDVk7VnlC/y1BAnaYZL3vbPIP8Nhm0Ae5DJe0KExr/SdMJQ==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.5.0.tgz",
+			"integrity": "sha512-9y2+uGnESw/oyOI3eww9yaxdZyHq7XvprfP/eeoCsjqKYts2yRlsHS/SgjPDV8FyMfn2nbMy8YzUk6nyvdLOpQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.3.0",
-				"jest-message-util": "^25.3.0",
-				"jest-mock": "^25.3.0",
-				"jest-util": "^25.3.0",
+				"@jest/types": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-mock": "^25.5.0",
+				"jest-util": "^25.5.0",
 				"lolex": "^5.0.0"
 			}
 		},
+		"@jest/globals": {
+			"version": "25.5.2",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-25.5.2.tgz",
+			"integrity": "sha512-AgAS/Ny7Q2RCIj5kZ+0MuKM1wbF0WMLxbCVl/GOMoCNbODRdJ541IxJ98xnZdVSZXivKpJlNPIWa3QmY0l4CXA==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"expect": "^25.5.0"
+			}
+		},
 		"@jest/reporters": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.3.0.tgz",
-			"integrity": "sha512-1u0ZBygs0C9DhdYgLCrRfZfNKQa+9+J7Uo+Z9z0RWLHzgsxhoG32lrmMOtUw48yR6bLNELdvzormwUqSk4H4Vg==",
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.5.1.tgz",
+			"integrity": "sha512-3jbd8pPDTuhYJ7vqiHXbSwTJQNavczPs+f1kRprRDxETeE3u6srJ+f0NPuwvOmk+lmunZzPkYWIFZDLHQPkviw==",
 			"dev": true,
 			"requires": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^25.3.0",
-				"@jest/test-result": "^25.3.0",
-				"@jest/transform": "^25.3.0",
-				"@jest/types": "^25.3.0",
+				"@jest/console": "^25.5.0",
+				"@jest/test-result": "^25.5.0",
+				"@jest/transform": "^25.5.1",
+				"@jest/types": "^25.5.0",
 				"chalk": "^3.0.0",
 				"collect-v8-coverage": "^1.0.0",
 				"exit": "^0.1.2",
 				"glob": "^7.1.2",
+				"graceful-fs": "^4.2.4",
 				"istanbul-lib-coverage": "^3.0.0",
 				"istanbul-lib-instrument": "^4.0.0",
 				"istanbul-lib-report": "^3.0.0",
 				"istanbul-lib-source-maps": "^4.0.0",
 				"istanbul-reports": "^3.0.2",
-				"jest-haste-map": "^25.3.0",
-				"jest-resolve": "^25.3.0",
-				"jest-util": "^25.3.0",
-				"jest-worker": "^25.2.6",
+				"jest-haste-map": "^25.5.1",
+				"jest-resolve": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"jest-worker": "^25.5.0",
 				"node-notifier": "^6.0.0",
 				"slash": "^3.0.0",
 				"source-map": "^0.6.0",
 				"string-length": "^3.1.0",
 				"terminal-link": "^2.0.0",
-				"v8-to-istanbul": "^4.0.1"
+				"v8-to-istanbul": "^4.1.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -1746,6 +1765,12 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1776,16 +1801,22 @@
 			}
 		},
 		"@jest/source-map": {
-			"version": "25.2.6",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.2.6.tgz",
-			"integrity": "sha512-VuIRZF8M2zxYFGTEhkNSvQkUKafQro4y+mwUxy5ewRqs5N/ynSFUODYp3fy1zCnbCMy1pz3k+u57uCqx8QRSQQ==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.5.0.tgz",
+			"integrity": "sha512-eIGx0xN12yVpMcPaVpjXPnn3N30QGJCJQSkEDUt9x1fI1Gdvb07Ml6K5iN2hG7NmMP6FDmtPEssE3z6doOYUwQ==",
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0",
-				"graceful-fs": "^4.2.3",
+				"graceful-fs": "^4.2.4",
 				"source-map": "^0.6.0"
 			},
 			"dependencies": {
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1795,45 +1826,54 @@
 			}
 		},
 		"@jest/test-result": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.3.0.tgz",
-			"integrity": "sha512-mqrGuiiPXl1ap09Mydg4O782F3ouDQfsKqtQzIjitpwv3t1cHDwCto21jThw6WRRE+dKcWQvLG70GpyLJICfGw==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.5.0.tgz",
+			"integrity": "sha512-oV+hPJgXN7IQf/fHWkcS99y0smKLU2czLBJ9WA0jHITLst58HpQMtzSYxzaBvYc6U5U6jfoMthqsUlUlbRXs0A==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^25.3.0",
-				"@jest/types": "^25.3.0",
+				"@jest/console": "^25.5.0",
+				"@jest/types": "^25.5.0",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"collect-v8-coverage": "^1.0.0"
 			}
 		},
 		"@jest/test-sequencer": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.3.0.tgz",
-			"integrity": "sha512-Xvns3xbji7JCvVcDGvqJ/pf4IpmohPODumoPEZJ0/VgC5gI4XaNVIBET2Dq5Czu6Gk3xFcmhtthh/MBOTljdNg==",
+			"version": "25.5.2",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.5.2.tgz",
+			"integrity": "sha512-spQjGJ+QTjqB2NcZclkEpStF4uXxfpMfGAsW12dtxfjR9nsxTyTEYt8JUtrpxfYk8R1iTbcwkayekxZPB2MEiw==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^25.3.0",
-				"jest-haste-map": "^25.3.0",
-				"jest-runner": "^25.3.0",
-				"jest-runtime": "^25.3.0"
+				"@jest/test-result": "^25.5.0",
+				"graceful-fs": "^4.2.4",
+				"jest-haste-map": "^25.5.1",
+				"jest-runner": "^25.5.2",
+				"jest-runtime": "^25.5.2"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				}
 			}
 		},
 		"@jest/transform": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.3.0.tgz",
-			"integrity": "sha512-W01p8kTDvvEX6kd0tJc7Y5VdYyFaKwNWy1HQz6Jqlhu48z/8Gxp+yFCDVj+H8Rc7ezl3Mg0hDaGuFVkmHOqirg==",
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.5.1.tgz",
+			"integrity": "sha512-Y8CEoVwXb4QwA6Y/9uDkn0Xfz0finGkieuV0xkdF9UtZGJeLukD5nLkaVrVsODB1ojRWlaoD0AJZpVHCSnJEvg==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/types": "^25.3.0",
+				"@jest/types": "^25.5.0",
 				"babel-plugin-istanbul": "^6.0.0",
 				"chalk": "^3.0.0",
 				"convert-source-map": "^1.4.0",
 				"fast-json-stable-stringify": "^2.0.0",
-				"graceful-fs": "^4.2.3",
-				"jest-haste-map": "^25.3.0",
+				"graceful-fs": "^4.2.4",
+				"jest-haste-map": "^25.5.1",
 				"jest-regex-util": "^25.2.6",
-				"jest-util": "^25.3.0",
+				"jest-util": "^25.5.0",
 				"micromatch": "^4.0.2",
 				"pirates": "^4.0.1",
 				"realpath-native": "^2.0.0",
@@ -1894,6 +1934,12 @@
 					"requires": {
 						"to-regex-range": "^5.0.1"
 					}
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
 				},
 				"has-flag": {
 					"version": "4.0.0",
@@ -1962,9 +2008,9 @@
 			}
 		},
 		"@jest/types": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.3.0.tgz",
-			"integrity": "sha512-UkaDNewdqXAmCDbN2GlUM6amDKS78eCqiw/UmF5nE0mmLTd6moJkiZJML/X52Ke3LH7Swhw883IRXq8o9nWjVw==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+			"integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
 			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.0",
@@ -3587,15 +3633,15 @@
 			}
 		},
 		"@popperjs/core": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.3.3.tgz",
-			"integrity": "sha512-yEvVC8RfhRPkD9TUn7cFcLcgoJePgZRAOR7T21rcRY5I8tpuhzeWfGa7We7tB14fe9R7wENdqUABcMdwD4SQLw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.0.tgz",
+			"integrity": "sha512-NMrDy6EWh9TPdSRiHmHH2ye1v5U0gBD7pRYwSwJvomx7Bm4GG04vu63dYiVzebLOx2obPpJugew06xVP0Nk7hA==",
 			"dev": true
 		},
 		"@sindresorhus/is": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.0.tgz",
-			"integrity": "sha512-lXKXfypKo644k4Da4yXkPCrwcvn6SlUW2X2zFbuflKHNjf0w9htru01bo26uMhleMXsDmnZ12eJLdrAZa9MANg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.1.tgz",
+			"integrity": "sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg==",
 			"dev": true
 		},
 		"@sinonjs/commons": {
@@ -3608,15 +3654,15 @@
 			}
 		},
 		"@svgr/babel-plugin-add-jsx-attribute": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-5.0.1.tgz",
-			"integrity": "sha512-av76JbSudaN2CUOGuKQp5BVqLFidtojg4ApRTg1PBOVsskXK2ORwKnBYhIu0JLA6ynmuNDprlHNCD6IwLiYidw==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-5.4.0.tgz",
+			"integrity": "sha512-ZFf2gs/8/6B8PnSofI0inYXr2SDNTDScPXhN7k5EqD4aZ3gi6u+rbmZHVB8IM3wDyx8ntKACZbtXSm7oZGRqVg==",
 			"dev": true
 		},
 		"@svgr/babel-plugin-remove-jsx-attribute": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-5.0.1.tgz",
-			"integrity": "sha512-oXyByaDQEK4Ut/eC75698MDKnaadbWmp/LS2w22cZAaoObCkkiwYYgZTZ+bvb3moo//AxvKkBtNrlz6+xBb9ZQ==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-5.4.0.tgz",
+			"integrity": "sha512-yaS4o2PgUtwLFGTKbsiAy6D0o3ugcUhWK0Z45umJ66EPWunAz9fuFw2gJuje6wqQvQWOTJvIahUwndOXb7QCPg==",
 			"dev": true
 		},
 		"@svgr/babel-plugin-remove-jsx-empty-expression": {
@@ -3632,81 +3678,89 @@
 			"dev": true
 		},
 		"@svgr/babel-plugin-svg-dynamic-title": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-5.0.1.tgz",
-			"integrity": "sha512-IbFiDBvq5WpANPndjEom1Y9k1pHCNfJs87jCN1Lt8NEA7yrNVPSoAjBVmmfi0aVBERfp8IT/lgjn2a/S85lXGg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-5.4.0.tgz",
+			"integrity": "sha512-zSOZH8PdZOpuG1ZVx/cLVePB2ibo3WPpqo7gFIjLV9a0QsuQAzJiwwqmuEdTaW2pegyBE17Uu15mOgOcgabQZg==",
 			"dev": true
 		},
 		"@svgr/babel-plugin-svg-em-dimensions": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-5.0.1.tgz",
-			"integrity": "sha512-7kL9LtqCm1ca+zAbBsrD4ME3EQeVcRxkdrf2GsbKPgkzWJ+399vS4VqCP462+WvFRbG13jSwpNCrvhekdyvXsA==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-5.4.0.tgz",
+			"integrity": "sha512-cPzDbDA5oT/sPXDCUYoVXEmm3VIoAWAPT6mSPTJNbQaBNUuEKVKyGH93oDY4e42PYHRW67N5alJx/eEol20abw==",
 			"dev": true
 		},
 		"@svgr/babel-plugin-transform-react-native-svg": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-5.0.1.tgz",
-			"integrity": "sha512-ITG1jJ0zHQ4yft6ISQqlMW4fHIzsrSB/FmrMxAcJtkTjh9M2/9M8wfKxQya9NnTfZ5WMSlQjXMQNZmGQsuxRrw==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-5.4.0.tgz",
+			"integrity": "sha512-3eYP/SaopZ41GHwXma7Rmxcv9uRslRDTY1estspeB1w1ueZWd/tPlMfEOoccYpEMZU3jD4OU7YitnXcF5hLW2Q==",
 			"dev": true
 		},
 		"@svgr/babel-plugin-transform-svg-component": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-5.3.1.tgz",
-			"integrity": "sha512-LY5MTWhOBjOeKhZDL+vp/CBLz8ZJQmV1C/WBgGC2ex8qiiCKOs04sqUbmHqEw+ReisEAZVpPHXBFp3RdsB+1qQ==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-5.4.0.tgz",
+			"integrity": "sha512-zLl4Fl3NvKxxjWNkqEcpdSOpQ3LGVH2BNFQ6vjaK6sFo2IrSznrhURIPI0HAphKiiIwNYjAfE0TNoQDSZv0U9A==",
 			"dev": true
 		},
 		"@svgr/babel-preset": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-5.3.1.tgz",
-			"integrity": "sha512-9h7bIUXgSZ9N1Ocxxd8yk4Vgl0wL9cdzkYTTgjU+B0ccewBJg4OwZnWdqKuu/kzfqUfwfICUMygKQM/WWYd9lQ==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-5.4.0.tgz",
+			"integrity": "sha512-Gyx7cCxua04DBtyILTYdQxeO/pwfTBev6+eXTbVbxe4HTGhOUW6yo7PSbG2p6eJMl44j6XSequ0ZDP7bl0nu9A==",
 			"dev": true,
 			"requires": {
-				"@svgr/babel-plugin-add-jsx-attribute": "^5.0.1",
-				"@svgr/babel-plugin-remove-jsx-attribute": "^5.0.1",
+				"@svgr/babel-plugin-add-jsx-attribute": "^5.4.0",
+				"@svgr/babel-plugin-remove-jsx-attribute": "^5.4.0",
 				"@svgr/babel-plugin-remove-jsx-empty-expression": "^5.0.1",
 				"@svgr/babel-plugin-replace-jsx-attribute-value": "^5.0.1",
-				"@svgr/babel-plugin-svg-dynamic-title": "^5.0.1",
-				"@svgr/babel-plugin-svg-em-dimensions": "^5.0.1",
-				"@svgr/babel-plugin-transform-react-native-svg": "^5.0.1",
-				"@svgr/babel-plugin-transform-svg-component": "^5.3.1"
+				"@svgr/babel-plugin-svg-dynamic-title": "^5.4.0",
+				"@svgr/babel-plugin-svg-em-dimensions": "^5.4.0",
+				"@svgr/babel-plugin-transform-react-native-svg": "^5.4.0",
+				"@svgr/babel-plugin-transform-svg-component": "^5.4.0"
 			}
 		},
 		"@svgr/core": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-5.3.1.tgz",
-			"integrity": "sha512-ZmEEkYrOoylo40Sgl5HlNULu+zF1zqcZ87iglJR1r+id6+TL2tRs53HPiaKUkaPMd3x5C6ErNPlTwMLShaeMSw==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-5.4.0.tgz",
+			"integrity": "sha512-hWGm1DCCvd4IEn7VgDUHYiC597lUYhFau2lwJBYpQWDirYLkX4OsXu9IslPgJ9UpP7wsw3n2Ffv9sW7SXJVfqQ==",
 			"dev": true,
 			"requires": {
-				"@svgr/plugin-jsx": "^5.3.1",
-				"camelcase": "^5.3.1",
+				"@svgr/plugin-jsx": "^5.4.0",
+				"camelcase": "^6.0.0",
 				"cosmiconfig": "^6.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+					"dev": true
+				}
 			}
 		},
 		"@svgr/hast-util-to-babel-ast": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-5.0.1.tgz",
-			"integrity": "sha512-G7UHNPNhLyDK5p6RJvSh4TRpHszTxG8jPp5lAxC6Ez6O6rj1plEAjrCDdYj50mvilUuT9IKjqn87F8+agpKaSw==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-5.4.0.tgz",
+			"integrity": "sha512-+U0TZZpPsP2V1WvVhqAOSTk+N+CjYHdZx+x9UBa1eeeZDXwH8pt0CrQf2+SvRl/h2CAPRFkm+Ey96+jKP8Bsgg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.4.4"
+				"@babel/types": "^7.9.5"
 			}
 		},
 		"@svgr/plugin-jsx": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-5.3.1.tgz",
-			"integrity": "sha512-M4HQis1bJd10H1gLCYRKBulgOnxPj2Cxhx1rjMHhj+1BdGoKbFSeKLWA6uLsTm59Db6510f5ltE+N8UX0muEYg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-5.4.0.tgz",
+			"integrity": "sha512-SGzO4JZQ2HvGRKDzRga9YFSqOqaNrgLlQVaGvpZ2Iht2gwRp/tq+18Pvv9kS9ZqOMYgyix2LLxZMY1LOe9NPqw==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.7.5",
-				"@svgr/babel-preset": "^5.3.1",
-				"@svgr/hast-util-to-babel-ast": "^5.0.1",
+				"@svgr/babel-preset": "^5.4.0",
+				"@svgr/hast-util-to-babel-ast": "^5.4.0",
 				"svg-parser": "^2.0.2"
 			}
 		},
 		"@svgr/plugin-svgo": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-5.3.0.tgz",
-			"integrity": "sha512-rQw558t/pPPA/aWrazLDt3xIuxh9zDuUcQUeR8EO6yiYftkjT7My1MLPz1pha1LhkJCR1ug83fp+TPRYkV9EIQ==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-5.4.0.tgz",
+			"integrity": "sha512-3Cgv3aYi1l6SHyzArV9C36yo4kgwVdF3zPQUC6/aCDUeXAofDYwE5kk3e3oT5ZO2a0N3lB+lLGvipBG6lnG8EA==",
 			"dev": true,
 			"requires": {
 				"cosmiconfig": "^6.0.0",
@@ -3715,18 +3769,18 @@
 			}
 		},
 		"@svgr/webpack": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-5.3.1.tgz",
-			"integrity": "sha512-0IrfVMS3BlZ2mli5QqFw1ZGieBgTqmgVzvxejOap7CACTv3t+iBBynx3Ak+x5Sbqeat43ZJ0lXODiHZyts6hQA==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-5.4.0.tgz",
+			"integrity": "sha512-LjepnS/BSAvelnOnnzr6Gg0GcpLmnZ9ThGFK5WJtm1xOqdBE/1IACZU7MMdVzjyUkfFqGz87eRE4hFaSLiUwYg==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.9.0",
 				"@babel/plugin-transform-react-constant-elements": "^7.9.0",
-				"@babel/preset-env": "^7.9.0",
+				"@babel/preset-env": "^7.9.5",
 				"@babel/preset-react": "^7.9.4",
-				"@svgr/core": "^5.3.1",
-				"@svgr/plugin-jsx": "^5.3.1",
-				"@svgr/plugin-svgo": "^5.3.0",
+				"@svgr/core": "^5.4.0",
+				"@svgr/plugin-jsx": "^5.4.0",
+				"@svgr/plugin-svgo": "^5.4.0",
 				"loader-utils": "^2.0.0"
 			}
 		},
@@ -3803,9 +3857,9 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.0.10",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.10.tgz",
-			"integrity": "sha512-74fNdUGrWsgIB/V9kTO5FGHPWYY6Eqn+3Z7L6Hc4e/BxjYV7puvBqp5HwsVYYfLm6iURYBNCx4Ut37OF9yitCw==",
+			"version": "7.0.11",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.11.tgz",
+			"integrity": "sha512-ddHK5icION5U6q11+tV2f9Mo6CZVuT8GJKld2q9LqHSZbvLbH34Kcu2yFGckZut453+eQU6btIA3RihmnRgI+Q==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.3.0"
@@ -3843,6 +3897,15 @@
 			"requires": {
 				"@types/events": "*",
 				"@types/minimatch": "*",
+				"@types/node": "*"
+			}
+		},
+		"@types/graceful-fs": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
+			"integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+			"dev": true,
+			"requires": {
 				"@types/node": "*"
 			}
 		},
@@ -3996,14 +4059,24 @@
 			"integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
 			"dev": true
 		},
+		"@types/yauzl": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+			"integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "2.28.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.28.0.tgz",
-			"integrity": "sha512-4SL9OWjvFbHumM/Zh/ZeEjUFxrYKtdCi7At4GyKTbQlrj1HcphIDXlje4Uu4cY+qzszR5NdVin4CCm6AXCjd6w==",
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.30.0.tgz",
+			"integrity": "sha512-L3/tS9t+hAHksy8xuorhOzhdefN0ERPDWmR9CclsIGOUqGKy6tqc/P+SoXeJRye5gazkuPO0cK9MQRnolykzkA==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/typescript-estree": "2.28.0",
+				"@typescript-eslint/typescript-estree": "2.30.0",
 				"eslint-scope": "^5.0.0",
 				"eslint-utils": "^2.0.0"
 			},
@@ -4021,9 +4094,9 @@
 			}
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "2.28.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.28.0.tgz",
-			"integrity": "sha512-HDr8MP9wfwkiuqzRVkuM3BeDrOC4cKbO5a6BymZBHUt5y/2pL0BXD6I/C/ceq2IZoHWhcASk+5/zo+dwgu9V8Q==",
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.30.0.tgz",
+			"integrity": "sha512-nI5WOechrA0qAhnr+DzqwmqHsx7Ulr/+0H7bWCcClDhhWkSyZR5BmTvnBEyONwJCTWHfc5PAQExX24VD26IAVw==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.1.1",
@@ -4252,34 +4325,6 @@
 				"core-js": "^3.6.4"
 			},
 			"dependencies": {
-				"@wordpress/element": {
-					"version": "2.13.1",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.13.1.tgz",
-					"integrity": "sha512-7bP6ewZ5jogV8wltaNA0Y1yDrPF5zGHprX/zyz8KyQyn5b40YTuoi32HZ1ssYxDa9fFHwbBeFGwVJcyGeKyLpw==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.9.2",
-						"@wordpress/escape-html": "^1.8.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.8.0.tgz",
-					"integrity": "sha512-z7z+57nm9Dv3Hau0u3+17dJCbpWnh853VBF6JPID7rKnLPw2AOoRJtNHf4gLeBJTrG6M4cC8EG8Flarsuoxb2w==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.9.2"
-					}
-				},
-				"@wordpress/warning": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-1.1.0.tgz",
-					"integrity": "sha512-n1GDCX2yxxhFF9PeXWq1bInvdwYkYqbeBLHPIChGrS+B57FY4vWebVfKQbOoxZ8CZD1RBIj/KOv/sihuAdHDhg==",
-					"dev": true
-				},
 				"core-js": {
 					"version": "3.6.5",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
@@ -4295,9 +4340,9 @@
 			"dev": true
 		},
 		"@wordpress/components": {
-			"version": "9.4.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-9.4.1.tgz",
-			"integrity": "sha512-geUBZn9ESpkXGEpC2pXbY9uOGedPYawZRSVd0sT8ZOAZ4JDhXj7f0qqULTF/Q6PdYUItlTFvgGtGSAQUIZfZdQ==",
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-9.5.0.tgz",
+			"integrity": "sha512-lfIcVKwzwaFdjpNvlTnNmTvCpO+PBv60N53TkIc0pYM4oAP5YGMp1dYve4xLdTfuVzOkNQ32gs84iysc2GhqFg==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
@@ -4306,17 +4351,17 @@
 				"@emotion/native": "^10.0.22",
 				"@emotion/styled": "^10.0.23",
 				"@wordpress/a11y": "^2.9.0",
-				"@wordpress/compose": "^3.13.1",
+				"@wordpress/compose": "^3.14.0",
 				"@wordpress/deprecated": "^2.8.0",
 				"@wordpress/dom": "^2.9.0",
 				"@wordpress/element": "^2.13.1",
 				"@wordpress/hooks": "^2.8.0",
-				"@wordpress/i18n": "^3.11.0",
-				"@wordpress/icons": "^1.3.1",
+				"@wordpress/i18n": "^3.12.0",
+				"@wordpress/icons": "^1.4.0",
 				"@wordpress/is-shallow-equal": "^2.0.0",
-				"@wordpress/keycodes": "^2.11.0",
-				"@wordpress/primitives": "^1.3.1",
-				"@wordpress/rich-text": "^3.14.1",
+				"@wordpress/keycodes": "^2.12.0",
+				"@wordpress/primitives": "^1.4.0",
+				"@wordpress/rich-text": "^3.15.0",
 				"@wordpress/warning": "^1.1.0",
 				"classnames": "^2.2.5",
 				"clipboard": "^2.0.1",
@@ -4344,9 +4389,9 @@
 			}
 		},
 		"@wordpress/compose": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.13.1.tgz",
-			"integrity": "sha512-RlPWcePmsnVj6jxPIq92lh7zbc3vPJzZC5BCHC9v38zUxUSd0pd7q+vvs/Wzpv4t4pYy0saslUM9HTq+bS6nxA==",
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.14.0.tgz",
+			"integrity": "sha512-DdFIkb1Ko/7iMGcDX8j6BQWA123yvLISzaFalcF9QOW2bP30QhJiSCFyYGBU7QScnRBhY6Rl0Chh9wkAV032GA==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
@@ -4358,13 +4403,13 @@
 			}
 		},
 		"@wordpress/data": {
-			"version": "4.16.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.16.1.tgz",
-			"integrity": "sha512-QBsYs3/lqJ+EfUDTdCSI3I6FkaMCfPsg8PwizcHA5lFDjrYCHtgI4WQFM/lLmdciNWXLqO1U6FxbyZCcB6/Ong==",
+			"version": "4.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.17.0.tgz",
+			"integrity": "sha512-cq3dHjhGUHfolLJfZ8cdLINDPZjmsmnjX0KLTSXH8eHreDSG09M3Mq5sckE2o/omzrm/CIqsRHuHePOrYF+IHA==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
-				"@wordpress/compose": "^3.13.1",
+				"@wordpress/compose": "^3.14.0",
 				"@wordpress/deprecated": "^2.8.0",
 				"@wordpress/element": "^2.13.1",
 				"@wordpress/is-shallow-equal": "^2.0.0",
@@ -4380,9 +4425,9 @@
 			}
 		},
 		"@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-2.5.0.tgz",
-			"integrity": "sha512-cJ3imk7D7WtSkJoolHdeTecQmWgHBnFJ6L/R8DizGkfMEta/mRN8g23E4vJ1LbZJfLqTo8GWjTIp0kN2V9HLWA==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-2.6.0.tgz",
+			"integrity": "sha512-B8OUocYidV7x01yMiGH/hY58Pjnz0+VDAtJWb74NlZK0W+pRCewpD7ScZv8IhkYeFb76oO4xdhnhJbVrX9NvIA==",
 			"dev": true,
 			"requires": {
 				"json2php": "^0.0.4",
@@ -4442,9 +4487,9 @@
 			}
 		},
 		"@wordpress/eslint-plugin": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-5.0.1.tgz",
-			"integrity": "sha512-aIWfYjZ0ahDhapjrX6ZbbXc9JJZPT+1BikMG8eMRw7I3F3mfEB1SmflEmNMlf72fhhq/ZkeSGSxnkHB0+NSoig==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-5.1.0.tgz",
+			"integrity": "sha512-uWQ7eXezwnWqj3MUOeeNEkUY7o5zEHG4uX+PL0WgHlM6dZIl65Ae5/KoItOst9t5053RHQV+0rOMMbup9KPHGQ==",
 			"dev": true,
 			"requires": {
 				"@wordpress/prettier-config": "^0.2.0",
@@ -4469,12 +4514,6 @@
 					"requires": {
 						"type-fest": "^0.8.1"
 					}
-				},
-				"prettier": {
-					"version": "npm:wp-prettier@1.19.1",
-					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
-					"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
-					"dev": true
 				}
 			}
 		},
@@ -4488,9 +4527,9 @@
 			}
 		},
 		"@wordpress/i18n": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.11.0.tgz",
-			"integrity": "sha512-wcu8NBxaSu8b4Bj+Nt4dMQvziQrfdgTeEGSRy9GzJChTVpFdyZT88zAaPbK+W8yqFaX3zMSf4rHpZSP6QvWkQg==",
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.12.0.tgz",
+			"integrity": "sha512-QkdHd2Z2yTFItBnnzzjMW4IXJlofWMivct4BkgwRivrG7kLxE7nd2xMG3+hFkkdYGdzE67u8vmin0gmQ+14yPA==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
@@ -4502,14 +4541,14 @@
 			}
 		},
 		"@wordpress/icons": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-1.3.1.tgz",
-			"integrity": "sha512-jTIfr+v8oMYukVDP5WzCvAbaNUFVNA7wa/OfmbK/fQe30UuYjcBpyeOwFd8448TPS1IxXqPKpeYkXCGpWhb4Yw==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-1.4.0.tgz",
+			"integrity": "sha512-YNW1ocZddZ6c40QHiR/Q3yIPYzh4Fdcq/J4sJIkegwqEXltVknYa90RNaDG9xr+qMvXN5/wotYaLA+AP6pUfHA==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
 				"@wordpress/element": "^2.13.1",
-				"@wordpress/primitives": "^1.3.1"
+				"@wordpress/primitives": "^1.4.0"
 			}
 		},
 		"@wordpress/is-shallow-equal": {
@@ -4547,13 +4586,13 @@
 			}
 		},
 		"@wordpress/keycodes": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.11.0.tgz",
-			"integrity": "sha512-qSjUmFCJztu5iQr2kK+1giGG4bKziIo7F0mnMCZtdg+eA09dGwDAv+mc7lxEpKMtttE7qi6+PtGWEnl1ewk/wg==",
+			"version": "2.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.12.0.tgz",
+			"integrity": "sha512-7fUwfquRLmE4CvJahZTHdNn31heoDcyZ4acgEQR4iKYsKjX6dF1coZjUe693xbf/4r8GmsOg0/uYDImMdDm+1Q==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
-				"@wordpress/i18n": "^3.11.0",
+				"@wordpress/i18n": "^3.12.0",
 				"lodash": "^4.17.15"
 			}
 		},
@@ -4570,9 +4609,9 @@
 			"dev": true
 		},
 		"@wordpress/primitives": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-1.3.1.tgz",
-			"integrity": "sha512-inNdzzxsCNouBWfG3HvvwX7kt+Io1N6aLXPipNGak9Cj9D6q5BzoCA8w+/7LK4mCxvxm8TS0p1ZZDHuvoP1uNQ==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-1.4.0.tgz",
+			"integrity": "sha512-mlP7ikqBw761VK37RL7q5+tnjJujGFuDfJhjhxCXacM/06CpddPSfX+XctWTTn0Oaw1XI/nzK1wlqlIj7uwlrg==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
@@ -4602,19 +4641,19 @@
 			}
 		},
 		"@wordpress/rich-text": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.14.1.tgz",
-			"integrity": "sha512-REnjFXAukGXT9cqjSee1cp6EPYChlgQe0IQAVDBVbugLk2pcOQ1Qjr5439nXY/4RYXMhNxBjR3no23ccreUJUA==",
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.15.0.tgz",
+			"integrity": "sha512-fFA2c6CmcIKFpuqzWf+nS/fTfOHDfp+9eoODymrDZIhwmCzYwmUWIHjd96TSWWF38mKdIm/bc3scIupsksIpfQ==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
-				"@wordpress/compose": "^3.13.1",
-				"@wordpress/data": "^4.16.1",
+				"@wordpress/compose": "^3.14.0",
+				"@wordpress/data": "^4.17.0",
 				"@wordpress/deprecated": "^2.8.0",
 				"@wordpress/element": "^2.13.1",
 				"@wordpress/escape-html": "^1.8.0",
 				"@wordpress/is-shallow-equal": "^2.0.0",
-				"@wordpress/keycodes": "^2.11.0",
+				"@wordpress/keycodes": "^2.12.0",
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.15",
 				"memize": "^1.1.0",
@@ -4622,15 +4661,15 @@
 			}
 		},
 		"@wordpress/scripts": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-8.0.1.tgz",
-			"integrity": "sha512-seJGubn/gGzPNvYmbhnFOETImUJJU7vdwtCrCXDdZ5MdM2axLJkirGGgTBHYB5ziGDTgY10dDhtdkgvjgVlmFg==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-9.0.0.tgz",
+			"integrity": "sha512-29i0x0sUyKbT66/N0L13sr9EJqL2xeQg3aTsyCgl25Vk4mF9Cw2pVZ9jP6uzojZQpHQzNsQomBD5LO441P4yUg==",
 			"dev": true,
 			"requires": {
 				"@svgr/webpack": "^5.2.0",
 				"@wordpress/babel-preset-default": "^4.12.1",
-				"@wordpress/dependency-extraction-webpack-plugin": "^2.5.0",
-				"@wordpress/eslint-plugin": "^5.0.1",
+				"@wordpress/dependency-extraction-webpack-plugin": "^2.6.0",
+				"@wordpress/eslint-plugin": "^5.1.0",
 				"@wordpress/jest-preset-default": "^6.0.0",
 				"@wordpress/npm-package-json-lint-config": "^3.0.0",
 				"@wordpress/prettier-config": "^0.2.0",
@@ -4652,9 +4691,9 @@
 				"markdownlint": "^0.18.0",
 				"markdownlint-cli": "^0.21.0",
 				"minimist": "^1.2.0",
-				"npm-package-json-lint": "^4.0.3",
+				"npm-package-json-lint": "^5.0.0",
 				"prettier": "npm:wp-prettier@1.19.1",
-				"puppeteer": "^2.0.0",
+				"puppeteer": "npm:puppeteer-core@3.0.0",
 				"read-pkg-up": "^1.0.1",
 				"resolve-bin": "^0.4.0",
 				"source-map-loader": "^0.2.4",
@@ -5234,9 +5273,9 @@
 			},
 			"dependencies": {
 				"postcss-value-parser": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
-					"integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+					"integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
 					"dev": true
 				}
 			}
@@ -5274,17 +5313,18 @@
 			}
 		},
 		"babel-jest": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.3.0.tgz",
-			"integrity": "sha512-qiXeX1Cmw4JZ5yQ4H57WpkO0MZ61Qj+YnsVUwAMnDV5ls+yHon11XjarDdgP7H8lTmiEi6biiZA8y3Tmvx6pCg==",
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.5.1.tgz",
+			"integrity": "sha512-9dA9+GmMjIzgPnYtkhBg73gOo/RHqPmLruP3BaGL4KEX3Dwz6pI8auSN8G8+iuEG90+GSswyKvslN+JYSaacaQ==",
 			"dev": true,
 			"requires": {
-				"@jest/transform": "^25.3.0",
-				"@jest/types": "^25.3.0",
+				"@jest/transform": "^25.5.1",
+				"@jest/types": "^25.5.0",
 				"@types/babel__core": "^7.1.7",
 				"babel-plugin-istanbul": "^6.0.0",
-				"babel-preset-jest": "^25.3.0",
+				"babel-preset-jest": "^25.5.0",
 				"chalk": "^3.0.0",
+				"graceful-fs": "^4.2.4",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
@@ -5321,6 +5361,12 @@
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
 					"dev": true
 				},
 				"has-flag": {
@@ -5360,9 +5406,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.12.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-					"integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+					"version": "6.12.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+					"integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -5398,9 +5444,9 @@
 					}
 				},
 				"schema-utils": {
-					"version": "2.6.5",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.5.tgz",
-					"integrity": "sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==",
+					"version": "2.6.6",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.6.tgz",
+					"integrity": "sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==",
 					"dev": true,
 					"requires": {
 						"ajv": "^6.12.0",
@@ -5410,9 +5456,9 @@
 			}
 		},
 		"babel-plugin-dynamic-import-node": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
-			"integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+			"integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
 			"dev": true,
 			"requires": {
 				"object.assign": "^4.1.0"
@@ -5450,11 +5496,13 @@
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "25.2.6",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.2.6.tgz",
-			"integrity": "sha512-qE2xjMathybYxjiGFJg0mLFrz0qNp83aNZycWDY/SuHiZNq+vQfRQtuINqyXyue1ELd8Rd+1OhFSLjms8msMbw==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.5.0.tgz",
+			"integrity": "sha512-u+/W+WAjMlvoocYGTwthAiQSxDcJAyHpQ6oWlHdFZaaN+Rlk8Q7iiwDPg2lN/FyJtAYnKjFxbn7xus4HCFkg5g==",
 			"dev": true,
 			"requires": {
+				"@babel/template": "^7.3.3",
+				"@babel/types": "^7.3.3",
 				"@types/babel__traverse": "^7.0.6"
 			}
 		},
@@ -5494,12 +5542,12 @@
 			}
 		},
 		"babel-preset-jest": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.3.0.tgz",
-			"integrity": "sha512-tjdvLKNMwDI9r+QWz9sZUQGTq1dpoxjUqFUpEasAc7MOtHg9XuLT2fx0udFG+k1nvMV0WvHHVAN7VmCZ+1Zxbw==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.5.0.tgz",
+			"integrity": "sha512-8ZczygctQkBU+63DtSOKGh7tFL0CeCuz+1ieud9lJ1WPQ9O6A1a/r+LGn6Y705PA6whHQ3T1XuB/PmpfNYf8Fw==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "^25.2.6",
+				"babel-plugin-jest-hoist": "^25.5.0",
 				"babel-preset-current-node-syntax": "^0.1.2"
 			}
 		},
@@ -5635,6 +5683,40 @@
 				"file-uri-to-path": "1.0.0"
 			}
 		},
+		"bl": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+			"integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+			"dev": true,
+			"requires": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			},
+			"dependencies": {
+				"buffer": {
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+					"dev": true,
+					"requires": {
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
 		"bluebird": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -5725,9 +5807,9 @@
 			}
 		},
 		"body-scroll-lock": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-2.7.1.tgz",
-			"integrity": "sha512-hS53SQ8RhM0e4DsQ3PKz6Gr2O7Kpdh59TWU98GHjaQznL7y4dFycEPk7pFQAikqBaUSCArkc5E3pe7CWIt2fZA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.0.2.tgz",
+			"integrity": "sha512-PtItUun94iIupKry8J/h6SfRCLWZnly77KbPsTSKALmxfR282L8R0Ujkv7bydSZvLxAJS4sBJ3y/E6X8gYkGrQ==",
 			"dev": true
 		},
 		"boolbase": {
@@ -5882,13 +5964,13 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.11.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.1.tgz",
-			"integrity": "sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.0.tgz",
+			"integrity": "sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001038",
-				"electron-to-chromium": "^1.3.390",
+				"caniuse-lite": "^1.0.30001043",
+				"electron-to-chromium": "^1.3.413",
 				"node-releases": "^1.1.53",
 				"pkg-up": "^2.0.0"
 			}
@@ -6123,9 +6205,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001042",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001042.tgz",
-			"integrity": "sha512-igMQ4dlqnf4tWv0xjaaE02op9AJ2oQzXKjWf4EuAHFN694Uo9/EfPVIPJcmn2WkU9RqozCxx5e2KPcVClHDbDw==",
+			"version": "1.0.30001048",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001048.tgz",
+			"integrity": "sha512-g1iSHKVxornw0K8LG9LLdf+Fxnv7T1Z+mMsf0/YYLclQX4Cd522Ap0Lrw6NFqHgezit78dtyWxzlV2Xfc7vgRg==",
 			"dev": true
 		},
 		"capture-exit": {
@@ -6551,9 +6633,9 @@
 			}
 		},
 		"command-exists": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
-			"integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==",
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+			"integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
 			"dev": true
 		},
 		"commander": {
@@ -7620,9 +7702,9 @@
 			"dev": true
 		},
 		"cssstyle": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.2.0.tgz",
-			"integrity": "sha512-sEb3XFPx3jNnCAMtqrXPDeSgQr+jojtCeNf8cvMNMh1cG970+lljssvQDzPq6lmmJu2Vhqood/gtEomBiHOGnA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+			"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
 			"dev": true,
 			"requires": {
 				"cssom": "~0.3.6"
@@ -8154,9 +8236,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.408",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.408.tgz",
-			"integrity": "sha512-vn1zWIxIdyl0MR72lr81/7kHYTRlDRjJT4ocp8dtb85VhH46J3lNqDMEBljAKPKgguqjK0+WAbf3IL6ZKw72kQ==",
+			"version": "1.3.424",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.424.tgz",
+			"integrity": "sha512-h8apsMr1RK3OusH8iwxlJ7TZkpgWfg2HvTXZ3o1w9R/SeRKX0hEGMQmRyTWijZAloHfmfwTLaPurVqKWdFC5dw==",
 			"dev": true
 		},
 		"elliptic": {
@@ -8571,9 +8653,9 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "6.10.1",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
-			"integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
+			"integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
 			"dev": true,
 			"requires": {
 				"get-stdin": "^6.0.0"
@@ -8669,9 +8751,9 @@
 			},
 			"dependencies": {
 				"resolve": {
-					"version": "1.15.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-					"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
 					"dev": true,
 					"requires": {
 						"path-parse": "^1.0.6"
@@ -8742,18 +8824,18 @@
 			"dev": true
 		},
 		"esquery": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.0.tgz",
-			"integrity": "sha512-/5qB+Mb0m2bh86tjGbA8pB0qBfdmCIK6ZNPjcw4/TtEH0+tTf0wLA5HK4KMTweSMwLGHwBDWCBV+6+2+EuHmgg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+			"integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^5.0.0"
+				"estraverse": "^5.1.0"
 			},
 			"dependencies": {
 				"estraverse": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.0.0.tgz",
-					"integrity": "sha512-j3acdrMzqrxmJTNj5dbr1YbjacrYgAxVMeF0gK16E3j494mOe7xygM/ZLIguEQ0ETwAg2hlJCtHRGav+y0Ny5A==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+					"integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
 					"dev": true
 				}
 			}
@@ -8918,16 +9000,16 @@
 			}
 		},
 		"expect": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-25.3.0.tgz",
-			"integrity": "sha512-buboTXML2h/L0Kh44Ys2Cx49mX20ISc5KDirkxIs3Q9AJv0kazweUAbukegr+nHDOvFRKmxdojjIHCjqAceYfg==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-25.5.0.tgz",
+			"integrity": "sha512-w7KAXo0+6qqZZhovCaBVPSIqQp7/UTcx4M9uKt2m6pd2VB1voyC8JizLRqeEqud3AAVP02g+hbErDu5gu64tlA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.3.0",
+				"@jest/types": "^25.5.0",
 				"ansi-styles": "^4.0.0",
 				"jest-get-type": "^25.2.6",
-				"jest-matcher-utils": "^25.3.0",
-				"jest-message-util": "^25.3.0",
+				"jest-matcher-utils": "^25.5.0",
+				"jest-message-util": "^25.5.0",
 				"jest-regex-util": "^25.2.6"
 			},
 			"dependencies": {
@@ -9129,31 +9211,25 @@
 			}
 		},
 		"extract-zip": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-			"integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.0.tgz",
+			"integrity": "sha512-i42GQ498yibjdvIhivUsRslx608whtGoFIhF26Z7O4MYncBxp8CwalOs1lnHy21A9sIohWO2+uiE4SRtC9JXDg==",
 			"dev": true,
 			"requires": {
-				"concat-stream": "^1.6.2",
-				"debug": "^2.6.9",
-				"mkdirp": "^0.5.4",
+				"@types/yauzl": "^2.9.1",
+				"debug": "^4.1.1",
+				"get-stream": "^5.1.0",
 				"yauzl": "^2.10.0"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+				"get-stream": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"pump": "^3.0.0"
 					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
 				}
 			}
 		},
@@ -9640,6 +9716,12 @@
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
 			}
+		},
+		"fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"dev": true
 		},
 		"fs-exists-sync": {
 			"version": "0.1.0",
@@ -10938,18 +11020,16 @@
 			"dev": true
 		},
 		"globby": {
-			"version": "10.0.2",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
-			"integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
+			"integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
 			"dev": true,
 			"requires": {
-				"@types/glob": "^7.1.1",
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.0.3",
-				"glob": "^7.1.3",
-				"ignore": "^5.1.1",
-				"merge2": "^1.2.3",
+				"fast-glob": "^3.1.1",
+				"ignore": "^5.1.4",
+				"merge2": "^1.3.0",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
@@ -11607,13 +11687,10 @@
 					"dev": true
 				},
 				"run-async": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
-					"integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
-					"dev": true,
-					"requires": {
-						"is-promise": "^2.1.0"
-					}
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+					"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+					"dev": true
 				},
 				"string-width": {
 					"version": "4.2.0",
@@ -11697,9 +11774,9 @@
 			"dev": true
 		},
 		"irregular-plurals": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-2.0.0.tgz",
-			"integrity": "sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.2.0.tgz",
+			"integrity": "sha512-YqTdPLfwP7YFN0SsD3QUVCkm9ZG2VzOXv3DOrw5G5mkMbVwptTwVcFv7/C0vOpBmgTxAeTG19XpUs1E522LW9Q==",
 			"dev": true
 		},
 		"is-accessor-descriptor": {
@@ -12130,9 +12207,9 @@
 					"dev": true
 				},
 				"make-dir": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-					"integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 					"dev": true,
 					"requires": {
 						"semver": "^6.0.0"
@@ -12185,14 +12262,14 @@
 			}
 		},
 		"jest": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-25.3.0.tgz",
-			"integrity": "sha512-iKd5ShQSHzFT5IL/6h5RZJhApgqXSoPxhp5HEi94v6OAw9QkF8T7X+liEU2eEHJ1eMFYTHmeWLrpBWulsDpaUg==",
+			"version": "25.5.2",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-25.5.2.tgz",
+			"integrity": "sha512-uJwrQNpNwhlP4SX3lpvjc5ucOULeWUCQCfrREqvQW5phAy04q5lQPsGM6Z0T1Psdnuf9CkycpoNEL6O3FMGcsg==",
 			"dev": true,
 			"requires": {
-				"@jest/core": "^25.3.0",
+				"@jest/core": "^25.5.2",
 				"import-local": "^3.0.2",
-				"jest-cli": "^25.3.0"
+				"jest-cli": "^25.5.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -12240,6 +12317,12 @@
 						"path-exists": "^4.0.0"
 					}
 				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -12257,21 +12340,22 @@
 					}
 				},
 				"jest-cli": {
-					"version": "25.3.0",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-25.3.0.tgz",
-					"integrity": "sha512-XpNQPlW1tzpP7RGG8dxpkRegYDuLjzSiENu92+CYM87nEbmEPb3b4+yo8xcsHOnj0AG7DUt9b3uG8LuHI3MDzw==",
+					"version": "25.5.2",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-25.5.2.tgz",
+					"integrity": "sha512-jbOJ4oOIJptg5mjNQZWyHkv33sXCIFT2UnkYwlZvyVU/0nz5nmIlIx57iTgHkmeRBp1VkK2qPZhjCDwHmxNKgA==",
 					"dev": true,
 					"requires": {
-						"@jest/core": "^25.3.0",
-						"@jest/test-result": "^25.3.0",
-						"@jest/types": "^25.3.0",
+						"@jest/core": "^25.5.2",
+						"@jest/test-result": "^25.5.0",
+						"@jest/types": "^25.5.0",
 						"chalk": "^3.0.0",
 						"exit": "^0.1.2",
+						"graceful-fs": "^4.2.4",
 						"import-local": "^3.0.2",
 						"is-ci": "^2.0.0",
-						"jest-config": "^25.3.0",
-						"jest-util": "^25.3.0",
-						"jest-validate": "^25.3.0",
+						"jest-config": "^25.5.2",
+						"jest-util": "^25.5.0",
+						"jest-validate": "^25.5.0",
 						"prompts": "^2.0.1",
 						"realpath-native": "^2.0.0",
 						"yargs": "^15.3.1"
@@ -12337,12 +12421,12 @@
 			}
 		},
 		"jest-changed-files": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.3.0.tgz",
-			"integrity": "sha512-eqd5hyLbUjIVvLlJ3vQ/MoPxsxfESVXG9gvU19XXjKzxr+dXmZIqCXiY0OiYaibwlHZBJl2Vebkc0ADEMzCXew==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.5.0.tgz",
+			"integrity": "sha512-EOw9QEqapsDT7mKF162m8HFzRPbmP8qJQny6ldVOdOVBz3ACgPm/1nAn5fPQ/NDaYhX/AHkrGwwkCncpAVSXcw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.3.0",
+				"@jest/types": "^25.5.0",
 				"execa": "^3.2.0",
 				"throat": "^5.0.0"
 			},
@@ -12439,28 +12523,29 @@
 			}
 		},
 		"jest-config": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.3.0.tgz",
-			"integrity": "sha512-CmF1JnNWFmoCSPC4tnU52wnVBpuxHjilA40qH/03IHxIevkjUInSMwaDeE6ACfxMPTLidBGBCO3EbxvzPbo8wA==",
+			"version": "25.5.2",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.5.2.tgz",
+			"integrity": "sha512-6KVTvhJYyXQVFMDxMCxqf9IgdI0dhdaIKR9WN9U+w3xcvNEWCgwzK5LaSx6hvthgh/sukJb3bC4jMnIUXkWu+A==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^25.3.0",
-				"@jest/types": "^25.3.0",
-				"babel-jest": "^25.3.0",
+				"@jest/test-sequencer": "^25.5.2",
+				"@jest/types": "^25.5.0",
+				"babel-jest": "^25.5.1",
 				"chalk": "^3.0.0",
 				"deepmerge": "^4.2.2",
 				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^25.3.0",
-				"jest-environment-node": "^25.3.0",
+				"graceful-fs": "^4.2.4",
+				"jest-environment-jsdom": "^25.5.0",
+				"jest-environment-node": "^25.5.0",
 				"jest-get-type": "^25.2.6",
-				"jest-jasmine2": "^25.3.0",
+				"jest-jasmine2": "^25.5.2",
 				"jest-regex-util": "^25.2.6",
-				"jest-resolve": "^25.3.0",
-				"jest-util": "^25.3.0",
-				"jest-validate": "^25.3.0",
+				"jest-resolve": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"jest-validate": "^25.5.0",
 				"micromatch": "^4.0.2",
-				"pretty-format": "^25.3.0",
+				"pretty-format": "^25.5.0",
 				"realpath-native": "^2.0.0"
 			},
 			"dependencies": {
@@ -12522,6 +12607,12 @@
 					"requires": {
 						"to-regex-range": "^5.0.1"
 					}
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
 				},
 				"has-flag": {
 					"version": "4.0.0",
@@ -12633,15 +12724,15 @@
 			}
 		},
 		"jest-diff": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.3.0.tgz",
-			"integrity": "sha512-vyvs6RPoVdiwARwY4kqFWd4PirPLm2dmmkNzKqo38uZOzJvLee87yzDjIZLmY1SjM3XR5DwsUH+cdQ12vgqi1w==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+			"integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
 			"dev": true,
 			"requires": {
 				"chalk": "^3.0.0",
 				"diff-sequences": "^25.2.6",
 				"jest-get-type": "^25.2.6",
-				"pretty-format": "^25.3.0"
+				"pretty-format": "^25.5.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -12706,16 +12797,16 @@
 			}
 		},
 		"jest-each": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.3.0.tgz",
-			"integrity": "sha512-aBfS4VOf/Qs95yUlX6d6WBv0szvOcTkTTyCIaLuQGj4bSHsT+Wd9dDngVHrCe5uytxpN8VM+NAloI6nbPjXfXw==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.5.0.tgz",
+			"integrity": "sha512-QBogUxna3D8vtiItvn54xXde7+vuzqRrEeaw8r1s+1TG9eZLVJE5ZkKoSUlqFwRjnlaA4hyKGiu9OlkFIuKnjA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.3.0",
+				"@jest/types": "^25.5.0",
 				"chalk": "^3.0.0",
 				"jest-get-type": "^25.2.6",
-				"jest-util": "^25.3.0",
-				"pretty-format": "^25.3.0"
+				"jest-util": "^25.5.0",
+				"pretty-format": "^25.5.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -12771,30 +12862,30 @@
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.3.0.tgz",
-			"integrity": "sha512-jdE4bQN+k2QEZ9sWOxsqDJvMzbdFSCN/4tw8X0TQaCqyzKz58PyEf41oIr4WO7ERdp7WaJGBSUKF7imR3UW1lg==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.5.0.tgz",
+			"integrity": "sha512-7Jr02ydaq4jaWMZLY+Skn8wL5nVIYpWvmeatOHL3tOcV3Zw8sjnPpx+ZdeBfc457p8jCR9J6YCc+Lga0oIy62A==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^25.3.0",
-				"@jest/fake-timers": "^25.3.0",
-				"@jest/types": "^25.3.0",
-				"jest-mock": "^25.3.0",
-				"jest-util": "^25.3.0",
+				"@jest/environment": "^25.5.0",
+				"@jest/fake-timers": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"jest-mock": "^25.5.0",
+				"jest-util": "^25.5.0",
 				"jsdom": "^15.2.1"
 			}
 		},
 		"jest-environment-node": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.3.0.tgz",
-			"integrity": "sha512-XO09S29Nx1NU7TiMPHMoDIkxoGBuKSTbE+sHp0gXbeLDXhIdhysUI25kOqFFSD9AuDgvPvxWCXrvNqiFsOH33g==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.5.0.tgz",
+			"integrity": "sha512-iuxK6rQR2En9EID+2k+IBs5fCFd919gVVK5BeND82fYeLWPqvRcFNPKu9+gxTwfB5XwBGBvZ0HFQa+cHtIoslA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^25.3.0",
-				"@jest/fake-timers": "^25.3.0",
-				"@jest/types": "^25.3.0",
-				"jest-mock": "^25.3.0",
-				"jest-util": "^25.3.0",
+				"@jest/environment": "^25.5.0",
+				"@jest/fake-timers": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"jest-mock": "^25.5.0",
+				"jest-util": "^25.5.0",
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
@@ -12877,19 +12968,20 @@
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.3.0.tgz",
-			"integrity": "sha512-LjXaRa+F8wwtSxo9G+hHD/Cp63PPQzvaBL9XCVoJD2rrcJO0Zr2+YYzAFWWYJ5GlPUkoaJFJtOuk0sL6MJY80A==",
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.5.1.tgz",
+			"integrity": "sha512-dddgh9UZjV7SCDQUrQ+5t9yy8iEgKc1AKqZR9YDww8xsVOtzPQSMVLDChc21+g29oTRexb9/B0bIlZL+sWmvAQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.3.0",
+				"@jest/types": "^25.5.0",
+				"@types/graceful-fs": "^4.1.2",
 				"anymatch": "^3.0.3",
 				"fb-watchman": "^2.0.0",
 				"fsevents": "^2.1.2",
-				"graceful-fs": "^4.2.3",
-				"jest-serializer": "^25.2.6",
-				"jest-util": "^25.3.0",
-				"jest-worker": "^25.2.6",
+				"graceful-fs": "^4.2.4",
+				"jest-serializer": "^25.5.0",
+				"jest-util": "^25.5.0",
+				"jest-worker": "^25.5.0",
 				"micromatch": "^4.0.2",
 				"sane": "^4.0.3",
 				"walker": "^1.0.7",
@@ -12925,11 +13017,17 @@
 					}
 				},
 				"fsevents": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+					"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
 					"dev": true,
 					"optional": true
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
 				},
 				"is-number": {
 					"version": "7.0.0",
@@ -12968,27 +13066,27 @@
 			}
 		},
 		"jest-jasmine2": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.3.0.tgz",
-			"integrity": "sha512-NCYOGE6+HNzYFSui52SefgpsnIzvxjn6KAgqw66BdRp37xpMD/4kujDHLNW5bS5i53os5TcMn6jYrzQRO8VPrQ==",
+			"version": "25.5.2",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.5.2.tgz",
+			"integrity": "sha512-wRtHAy97F4hafJgnh5CwI/N1tDo7z+urteQAyr3rjK7X3TZWX5hSV4cO7WIBKLDV0kPICCmsGiNYs1caeHD/sQ==",
 			"dev": true,
 			"requires": {
 				"@babel/traverse": "^7.1.0",
-				"@jest/environment": "^25.3.0",
-				"@jest/source-map": "^25.2.6",
-				"@jest/test-result": "^25.3.0",
-				"@jest/types": "^25.3.0",
+				"@jest/environment": "^25.5.0",
+				"@jest/source-map": "^25.5.0",
+				"@jest/test-result": "^25.5.0",
+				"@jest/types": "^25.5.0",
 				"chalk": "^3.0.0",
 				"co": "^4.6.0",
-				"expect": "^25.3.0",
+				"expect": "^25.5.0",
 				"is-generator-fn": "^2.0.0",
-				"jest-each": "^25.3.0",
-				"jest-matcher-utils": "^25.3.0",
-				"jest-message-util": "^25.3.0",
-				"jest-runtime": "^25.3.0",
-				"jest-snapshot": "^25.3.0",
-				"jest-util": "^25.3.0",
-				"pretty-format": "^25.3.0",
+				"jest-each": "^25.5.0",
+				"jest-matcher-utils": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-runtime": "^25.5.2",
+				"jest-snapshot": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"pretty-format": "^25.5.0",
 				"throat": "^5.0.0"
 			},
 			"dependencies": {
@@ -13045,25 +13143,25 @@
 			}
 		},
 		"jest-leak-detector": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.3.0.tgz",
-			"integrity": "sha512-jk7k24dMIfk8LUSQQGN8PyOy9+J0NAfHZWiDmUDYVMctY8FLJQ1eQ8+PjMoN8PgwhLIggUqgYJnyRFvUz3jLRw==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.5.0.tgz",
+			"integrity": "sha512-rV7JdLsanS8OkdDpZtgBf61L5xZ4NnYLBq72r6ldxahJWWczZjXawRsoHyXzibM5ed7C2QRjpp6ypgwGdKyoVA==",
 			"dev": true,
 			"requires": {
 				"jest-get-type": "^25.2.6",
-				"pretty-format": "^25.3.0"
+				"pretty-format": "^25.5.0"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.3.0.tgz",
-			"integrity": "sha512-ZBUJ2fchNIZt+fyzkuCFBb8SKaU//Rln45augfUtbHaGyVxCO++ANARdBK9oPGXU3hEDgyy7UHnOP/qNOJXFUg==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz",
+			"integrity": "sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==",
 			"dev": true,
 			"requires": {
 				"chalk": "^3.0.0",
-				"jest-diff": "^25.3.0",
+				"jest-diff": "^25.5.0",
 				"jest-get-type": "^25.2.6",
-				"pretty-format": "^25.3.0"
+				"pretty-format": "^25.5.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -13119,15 +13217,16 @@
 			}
 		},
 		"jest-message-util": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.3.0.tgz",
-			"integrity": "sha512-5QNy9Id4WxJbRITEbA1T1kem9bk7y2fD0updZMSTNHtbEDnYOGLDPAuFBhFgVmOZpv0n6OMdVkK+WhyXEPCcOw==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.5.0.tgz",
+			"integrity": "sha512-ezddz3YCT/LT0SKAmylVyWWIGYoKHOFOFXx3/nA4m794lfVUskMcwhip6vTgdVrOtYdjeQeis2ypzes9mZb4EA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@jest/types": "^25.3.0",
+				"@jest/types": "^25.5.0",
 				"@types/stack-utils": "^1.0.1",
 				"chalk": "^3.0.0",
+				"graceful-fs": "^4.2.4",
 				"micromatch": "^4.0.2",
 				"slash": "^3.0.0",
 				"stack-utils": "^1.0.1"
@@ -13186,6 +13285,12 @@
 						"to-regex-range": "^5.0.1"
 					}
 				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -13235,12 +13340,12 @@
 			}
 		},
 		"jest-mock": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.3.0.tgz",
-			"integrity": "sha512-yRn6GbuqB4j3aYu+Z1ezwRiZfp0o9om5uOcBovVtkcRLeBCNP5mT0ysdenUsxAHnQUgGwPOE1wwhtQYe6NKirQ==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.5.0.tgz",
+			"integrity": "sha512-eXWuTV8mKzp/ovHc5+3USJMYsTBhyQ+5A1Mak35dey/RG8GlM4YWVylZuGgVXinaW6tpvk/RSecmF37FKUlpXA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.3.0"
+				"@jest/types": "^25.5.0"
 			}
 		},
 		"jest-pnp-resolver": {
@@ -13266,17 +13371,20 @@
 			"dev": true
 		},
 		"jest-resolve": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.3.0.tgz",
-			"integrity": "sha512-IHoQAAybulsJ+ZgWis+ekYKDAoFkVH5Nx/znpb41zRtpxj4fr2WNV9iDqavdSm8GIpMlsfZxbC/fV9DhW0q9VQ==",
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.5.1.tgz",
+			"integrity": "sha512-Hc09hYch5aWdtejsUZhA+vSzcotf7fajSlPA6EZPE1RmPBAD39XtJhvHWFStid58iit4IPDLI/Da4cwdDmAHiQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.3.0",
+				"@jest/types": "^25.5.0",
 				"browser-resolve": "^1.11.3",
 				"chalk": "^3.0.0",
+				"graceful-fs": "^4.2.4",
 				"jest-pnp-resolver": "^1.2.1",
+				"read-pkg-up": "^7.0.1",
 				"realpath-native": "^2.0.0",
-				"resolve": "^1.15.1"
+				"resolve": "^1.17.0",
+				"slash": "^3.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -13314,20 +13422,97 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+					"dev": true,
+					"requires": {
+						"@types/normalize-package-data": "^2.4.0",
+						"normalize-package-data": "^2.5.0",
+						"parse-json": "^5.0.0",
+						"type-fest": "^0.6.0"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.6.0",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+							"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+							"dev": true
+						}
+					}
+				},
+				"read-pkg-up": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+					"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.1.0",
+						"read-pkg": "^5.2.0",
+						"type-fest": "^0.8.1"
+					}
+				},
 				"resolve": {
-					"version": "1.15.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-					"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
 					"dev": true,
 					"requires": {
 						"path-parse": "^1.0.6"
 					}
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "7.1.0",
@@ -13341,39 +13526,39 @@
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.3.0.tgz",
-			"integrity": "sha512-bDUlLYmHW+f7J7KgcY2lkq8EMRqKonRl0XoD4Wp5SJkgAxKJnsaIOlrrVNTfXYf+YOu3VCjm/Ac2hPF2nfsCIA==",
+			"version": "25.5.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.5.2.tgz",
+			"integrity": "sha512-4xlPp6/SFFZj7g7WkhoKEEWsYqmAK6WcmFFRfDJ0K4T2f/MCJgFEPqv1F88ro6ZJdpOti08CxGku4gBwau/RjQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.3.0",
+				"@jest/types": "^25.5.0",
 				"jest-regex-util": "^25.2.6",
-				"jest-snapshot": "^25.3.0"
+				"jest-snapshot": "^25.5.1"
 			}
 		},
 		"jest-runner": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.3.0.tgz",
-			"integrity": "sha512-csDqSC9qGHYWDrzrElzEgFbteztFeZJmKhSgY5jlCIcN0+PhActzRNku0DA1Xa1HxGOb0/AfbP1EGJlP4fGPtA==",
+			"version": "25.5.2",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.5.2.tgz",
+			"integrity": "sha512-GvaM0AWSfyer46BEranPSmKoNNW9RqLGnjKftE6I5Ia6cfjdHHeTHAus7Mh9PdjWzGqrXsLSGdErX+4wMvN3rQ==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^25.3.0",
-				"@jest/environment": "^25.3.0",
-				"@jest/test-result": "^25.3.0",
-				"@jest/types": "^25.3.0",
+				"@jest/console": "^25.5.0",
+				"@jest/environment": "^25.5.0",
+				"@jest/test-result": "^25.5.0",
+				"@jest/types": "^25.5.0",
 				"chalk": "^3.0.0",
 				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.3",
-				"jest-config": "^25.3.0",
+				"graceful-fs": "^4.2.4",
+				"jest-config": "^25.5.2",
 				"jest-docblock": "^25.3.0",
-				"jest-haste-map": "^25.3.0",
-				"jest-jasmine2": "^25.3.0",
-				"jest-leak-detector": "^25.3.0",
-				"jest-message-util": "^25.3.0",
-				"jest-resolve": "^25.3.0",
-				"jest-runtime": "^25.3.0",
-				"jest-util": "^25.3.0",
-				"jest-worker": "^25.2.6",
+				"jest-haste-map": "^25.5.1",
+				"jest-jasmine2": "^25.5.2",
+				"jest-leak-detector": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-resolve": "^25.5.1",
+				"jest-runtime": "^25.5.2",
+				"jest-util": "^25.5.0",
+				"jest-worker": "^25.5.0",
 				"source-map-support": "^0.5.6",
 				"throat": "^5.0.0"
 			},
@@ -13413,6 +13598,12 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -13431,32 +13622,33 @@
 			}
 		},
 		"jest-runtime": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.3.0.tgz",
-			"integrity": "sha512-gn5KYB1wxXRM3nfw8fVpthFu60vxQUCr+ShGq41+ZBFF3DRHZRKj3HDWVAVB4iTNBj2y04QeAo5cZ/boYaPg0w==",
+			"version": "25.5.2",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.5.2.tgz",
+			"integrity": "sha512-UQTPBnE73qpGMKAXYB2agoC+6hMyT3dWXVL+cYibCFRm0tx2A+0+8wceoivRCtxQGaQr52c+qMRIOIRqmhAgHQ==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^25.3.0",
-				"@jest/environment": "^25.3.0",
-				"@jest/source-map": "^25.2.6",
-				"@jest/test-result": "^25.3.0",
-				"@jest/transform": "^25.3.0",
-				"@jest/types": "^25.3.0",
+				"@jest/console": "^25.5.0",
+				"@jest/environment": "^25.5.0",
+				"@jest/globals": "^25.5.2",
+				"@jest/source-map": "^25.5.0",
+				"@jest/test-result": "^25.5.0",
+				"@jest/transform": "^25.5.1",
+				"@jest/types": "^25.5.0",
 				"@types/yargs": "^15.0.0",
 				"chalk": "^3.0.0",
 				"collect-v8-coverage": "^1.0.0",
 				"exit": "^0.1.2",
 				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.3",
-				"jest-config": "^25.3.0",
-				"jest-haste-map": "^25.3.0",
-				"jest-message-util": "^25.3.0",
-				"jest-mock": "^25.3.0",
+				"graceful-fs": "^4.2.4",
+				"jest-config": "^25.5.2",
+				"jest-haste-map": "^25.5.1",
+				"jest-message-util": "^25.5.0",
+				"jest-mock": "^25.5.0",
 				"jest-regex-util": "^25.2.6",
-				"jest-resolve": "^25.3.0",
-				"jest-snapshot": "^25.3.0",
-				"jest-util": "^25.3.0",
-				"jest-validate": "^25.3.0",
+				"jest-resolve": "^25.5.1",
+				"jest-snapshot": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"jest-validate": "^25.5.0",
 				"realpath-native": "^2.0.0",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0",
@@ -13498,6 +13690,12 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -13528,30 +13726,42 @@
 			}
 		},
 		"jest-serializer": {
-			"version": "25.2.6",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.2.6.tgz",
-			"integrity": "sha512-RMVCfZsezQS2Ww4kB5HJTMaMJ0asmC0BHlnobQC6yEtxiFKIxohFA4QSXSabKwSggaNkqxn6Z2VwdFCjhUWuiQ==",
-			"dev": true
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.5.0.tgz",
+			"integrity": "sha512-LxD8fY1lByomEPflwur9o4e2a5twSQ7TaVNLlFUuToIdoJuBt8tzHfCsZ42Ok6LkKXWzFWf3AGmheuLAA7LcCA==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.2.4"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				}
+			}
 		},
 		"jest-snapshot": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.3.0.tgz",
-			"integrity": "sha512-GGpR6Oro2htJPKh5RX4PR1xwo5jCEjtvSPLW1IS7N85y+2bWKbiknHpJJRKSdGXghElb5hWaeQASJI4IiRayGg==",
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.5.1.tgz",
+			"integrity": "sha512-C02JE1TUe64p2v1auUJ2ze5vcuv32tkv9PyhEb318e8XOKF7MOyXdJ7kdjbvrp3ChPLU2usI7Rjxs97Dj5P0uQ==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0",
-				"@jest/types": "^25.3.0",
+				"@jest/types": "^25.5.0",
 				"@types/prettier": "^1.19.0",
 				"chalk": "^3.0.0",
-				"expect": "^25.3.0",
-				"jest-diff": "^25.3.0",
+				"expect": "^25.5.0",
+				"graceful-fs": "^4.2.4",
+				"jest-diff": "^25.5.0",
 				"jest-get-type": "^25.2.6",
-				"jest-matcher-utils": "^25.3.0",
-				"jest-message-util": "^25.3.0",
-				"jest-resolve": "^25.3.0",
+				"jest-matcher-utils": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-resolve": "^25.5.1",
 				"make-dir": "^3.0.0",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^25.3.0",
+				"pretty-format": "^25.5.0",
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
@@ -13590,6 +13800,12 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -13597,9 +13813,9 @@
 					"dev": true
 				},
 				"make-dir": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-					"integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 					"dev": true,
 					"requires": {
 						"semver": "^6.0.0"
@@ -13623,13 +13839,14 @@
 			}
 		},
 		"jest-util": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.3.0.tgz",
-			"integrity": "sha512-dc625P/KS/CpWTJJJxKc4bA3A6c+PJGBAqS8JTJqx4HqPoKNqXg/Ec8biL2Z1TabwK7E7Ilf0/ukSEXM1VwzNA==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.5.0.tgz",
+			"integrity": "sha512-KVlX+WWg1zUTB9ktvhsg2PXZVdkI1NBevOJSkTKYAyXyH4QSvh+Lay/e/v+bmaFfrkfx43xD8QTfgobzlEXdIA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.3.0",
+				"@jest/types": "^25.5.0",
 				"chalk": "^3.0.0",
+				"graceful-fs": "^4.2.4",
 				"is-ci": "^2.0.0",
 				"make-dir": "^3.0.0"
 			},
@@ -13669,6 +13886,12 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -13676,9 +13899,9 @@
 					"dev": true
 				},
 				"make-dir": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-					"integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 					"dev": true,
 					"requires": {
 						"semver": "^6.0.0"
@@ -13702,17 +13925,17 @@
 			}
 		},
 		"jest-validate": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.3.0.tgz",
-			"integrity": "sha512-3WuXgIZ4HXUvW6gk9twFFkT9j6zUorKnF2oEY8VEsHb7x5LGvVlN3WUsbqazVKuyXwvikO2zFJ/YTySMsMje2w==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.5.0.tgz",
+			"integrity": "sha512-okUFKqhZIpo3jDdtUXUZ2LxGUZJIlfdYBvZb1aczzxrlyMlqdnnws9MOxezoLGhSaFc2XYaHNReNQfj5zPIWyQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.3.0",
+				"@jest/types": "^25.5.0",
 				"camelcase": "^5.3.1",
 				"chalk": "^3.0.0",
 				"jest-get-type": "^25.2.6",
 				"leven": "^3.1.0",
-				"pretty-format": "^25.3.0"
+				"pretty-format": "^25.5.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -13768,16 +13991,16 @@
 			}
 		},
 		"jest-watcher": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.3.0.tgz",
-			"integrity": "sha512-dtFkfidFCS9Ucv8azOg2hkiY3sgJEHeTLtGFHS+jfBEE7eRtrO6+2r1BokyDkaG2FOD7485r/SgpC1MFAENfeA==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.5.0.tgz",
+			"integrity": "sha512-XrSfJnVASEl+5+bb51V0Q7WQx65dTSk7NL4yDdVjPnRNpM0hG+ncFmDYJo9O8jaSRcAitVbuVawyXCRoxGrT5Q==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^25.3.0",
-				"@jest/types": "^25.3.0",
+				"@jest/test-result": "^25.5.0",
+				"@jest/types": "^25.5.0",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^3.0.0",
-				"jest-util": "^25.3.0",
+				"jest-util": "^25.5.0",
 				"string-length": "^3.1.0"
 			},
 			"dependencies": {
@@ -13834,9 +14057,9 @@
 			}
 		},
 		"jest-worker": {
-			"version": "25.2.6",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
-			"integrity": "sha512-FJn9XDUSxcOR4cwDzRfL1z56rUofNTFs539FGASpd50RHdb6EVkhxQqktodW2mI49l+W3H+tFJDotCHUQF6dmA==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.5.0.tgz",
+			"integrity": "sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==",
 			"dev": true,
 			"requires": {
 				"merge-stream": "^2.0.0",
@@ -14313,12 +14536,64 @@
 			"dev": true
 		},
 		"log-symbols": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-			"integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+			"integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.4.2"
+				"chalk": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+					"integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"lolex": {
@@ -14950,6 +15225,12 @@
 				"minimist": "^1.2.5"
 			}
 		},
+		"mkdirp-classic": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.2.tgz",
+			"integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g==",
+			"dev": true
+		},
 		"mkdirp-promise": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
@@ -15050,9 +15331,9 @@
 			}
 		},
 		"nan": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
 			"dev": true,
 			"optional": true
 		},
@@ -15340,32 +15621,32 @@
 			}
 		},
 		"npm-package-json-lint": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-4.6.0.tgz",
-			"integrity": "sha512-opoykADMeyGN2UuvypIYpysUXO4wdAYc8DPklO86kxF1YfxHnTXdEzm0K7BGE5CbEu6lweELQgvFej53din5xg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-5.1.0.tgz",
+			"integrity": "sha512-gPGpoFTbt0H4uPlubAKqHORg4+GObXqeYJh5ovkkSv76ua+t29vzRP4Qhm+9N/Q59Z3LT0tCmpoDlbTcNB7Jcg==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.11.0",
+				"ajv": "^6.12.2",
 				"ajv-errors": "^1.0.1",
-				"chalk": "^3.0.0",
-				"cosmiconfig": "^5.2.1",
+				"chalk": "^4.0.0",
+				"cosmiconfig": "^6.0.0",
 				"debug": "^4.1.1",
-				"globby": "^10.0.1",
+				"globby": "^11.0.0",
 				"ignore": "^5.1.4",
 				"is-plain-obj": "^2.1.0",
-				"jsonc-parser": "^2.2.0",
-				"log-symbols": "^3.0.0",
-				"meow": "^6.0.0",
-				"plur": "^3.1.1",
-				"semver": "^7.1.2",
+				"jsonc-parser": "^2.2.1",
+				"log-symbols": "^4.0.0",
+				"meow": "^6.1.0",
+				"plur": "^4.0.0",
+				"semver": "^7.3.2",
 				"slash": "^3.0.0",
-				"strip-json-comments": "^3.0.1"
+				"strip-json-comments": "^3.1.0"
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.12.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-					"integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+					"version": "6.12.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+					"integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -15385,9 +15666,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+					"integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -15409,18 +15690,6 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
-				"cosmiconfig": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-					"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-					"dev": true,
-					"requires": {
-						"import-fresh": "^2.0.0",
-						"is-directory": "^0.3.1",
-						"js-yaml": "^3.13.1",
-						"parse-json": "^4.0.0"
-					}
-				},
 				"fast-deep-equal": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
@@ -15439,36 +15708,10 @@
 					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
 					"dev": true
 				},
-				"import-fresh": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-					"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-					"dev": true,
-					"requires": {
-						"caller-path": "^2.0.0",
-						"resolve-from": "^3.0.0"
-					}
-				},
 				"is-plain-obj": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
 					"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-					"dev": true
-				},
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
-					}
-				},
-				"resolve-from": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
 					"dev": true
 				},
 				"semver": {
@@ -15620,10 +15863,35 @@
 			"dev": true
 		},
 		"object-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
-			"integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
-			"dev": true
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+			"integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.5",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+					"integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.5",
+						"is-regex": "^1.0.5",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.1",
+						"string.prototype.trimright": "^2.1.1"
+					}
+				}
+			}
 		},
 		"object-keys": {
 			"version": "1.1.1",
@@ -16220,12 +16488,12 @@
 			}
 		},
 		"plur": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/plur/-/plur-3.1.1.tgz",
-			"integrity": "sha512-t1Ax8KUvV3FFII8ltczPn2tJdjqbd1sIzu6t4JL7nQ3EyeL/lTrj5PWKb06ic5/6XYDr65rQ4uzQEGN70/6X5w==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
+			"integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
 			"dev": true,
 			"requires": {
-				"irregular-plurals": "^2.0.0"
+				"irregular-plurals": "^3.2.0"
 			}
 		},
 		"pn": {
@@ -16235,9 +16503,9 @@
 			"dev": true
 		},
 		"portfinder": {
-			"version": "1.0.25",
-			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
-			"integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
+			"version": "1.0.26",
+			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.26.tgz",
+			"integrity": "sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==",
 			"dev": true,
 			"requires": {
 				"async": "^2.6.2",
@@ -16452,12 +16720,12 @@
 			}
 		},
 		"pretty-format": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.3.0.tgz",
-			"integrity": "sha512-wToHwF8bkQknIcFkBqNfKu4+UZqnrLn/Vr+wwKQwwvPzkBfDDKp/qIabFqdgtoi5PEnM8LFByVsOrHoa3SpTVA==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+			"integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.3.0",
+				"@jest/types": "^25.5.0",
 				"ansi-regex": "^5.0.0",
 				"ansi-styles": "^4.0.0",
 				"react-is": "^16.12.0"
@@ -16695,30 +16963,32 @@
 			"dev": true
 		},
 		"puppeteer": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-2.1.1.tgz",
-			"integrity": "sha512-LWzaDVQkk1EPiuYeTOj+CZRIjda4k2s5w4MK4xoH2+kgWV/SDlkYHmxatDdtYrciHUKSXTsGgPgPP8ILVdBsxg==",
+			"version": "npm:puppeteer-core@3.0.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
+			"integrity": "sha512-oWjZFGMc0q2ak+8OxdmMffS79LIT0UEtmpV4h1/AARvESIqqKljf8mrfP+dQ2kas7XttsAZIxRBuWu7Y5JH8KQ==",
 			"dev": true,
 			"requires": {
 				"@types/mime-types": "^2.1.0",
 				"debug": "^4.1.0",
-				"extract-zip": "^1.6.6",
+				"extract-zip": "^2.0.0",
 				"https-proxy-agent": "^4.0.0",
 				"mime": "^2.0.3",
 				"mime-types": "^2.1.25",
 				"progress": "^2.0.1",
 				"proxy-from-env": "^1.0.0",
-				"rimraf": "^2.6.1",
-				"ws": "^6.1.0"
+				"rimraf": "^3.0.2",
+				"tar-fs": "^2.0.0",
+				"unbzip2-stream": "^1.3.3",
+				"ws": "^7.2.3"
 			},
 			"dependencies": {
-				"ws": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-					"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 					"dev": true,
 					"requires": {
-						"async-limiter": "~1.0.0"
+						"glob": "^7.1.3"
 					}
 				}
 			}
@@ -17206,40 +17476,40 @@
 			}
 		},
 		"reakit": {
-			"version": "1.0.0-rc.0",
-			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.0.0-rc.0.tgz",
-			"integrity": "sha512-jG9RfLE9DX3XP6xiUmindu8dJmd4rLs+ohQ2xppF9LVYQ/7Qa9B4kz8mNYbe42u8muE3nMM78T2RfXz+c/ZMsQ==",
+			"version": "1.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.0.0-rc.2.tgz",
+			"integrity": "sha512-+Snfc9Y/VMozEDXld3CJtvqgTyFCE67FXBmaDcvBuO3z2U/ZAHiAOBprF+ZN/QhsiVNMk1faj791vDBTokxS4w==",
 			"dev": true,
 			"requires": {
-				"@popperjs/core": "^2.1.0",
-				"body-scroll-lock": "^2.6.4",
-				"reakit-system": "^0.10.0",
-				"reakit-utils": "^0.10.0",
-				"reakit-warning": "^0.1.0"
+				"@popperjs/core": "^2.3.3",
+				"body-scroll-lock": "^3.0.1",
+				"reakit-system": "^0.12.0",
+				"reakit-utils": "^0.12.0",
+				"reakit-warning": "^0.3.0"
 			}
 		},
 		"reakit-system": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.10.0.tgz",
-			"integrity": "sha512-73ZI50NB2A6WAF3OsPJEEz73fax5cFiMoGMx3KxPT/AcS39rPqlBW6QkawtZC1HUebQXlsLxwZWicoFt8UubmQ==",
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.12.0.tgz",
+			"integrity": "sha512-lqesr7jmOEDEqKtPhEilCJNfYiLCeXOeU2lpPLBzO+CB2lsfF+A/NtrSpb3kuLu2mfIUSTTBxgaKdOBbfANmWA==",
 			"dev": true,
 			"requires": {
-				"reakit-utils": "^0.10.0"
+				"reakit-utils": "^0.12.0"
 			}
 		},
 		"reakit-utils": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.10.0.tgz",
-			"integrity": "sha512-s1+nqLYrHo54U38iETdY86+VD+CZBTqF9rxMmphuft1Iz1i+L+OqOVJMq5sviBkTiEz8zRMhrNLcjBERFiPnkA==",
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.12.0.tgz",
+			"integrity": "sha512-B0KUjRDu0GFDTi+FQApm4gynJGn18DuDdgCtcUytkN/AIJdKGaqHJ6FpeE1zMr1KAAUzZKrRqq/x93MrcQtvfQ==",
 			"dev": true
 		},
 		"reakit-warning": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.1.0.tgz",
-			"integrity": "sha512-nfujYGWoZ1lh6eAFTVQc2aNjrAEf30PHffJw8Q8tiJJY4Knoy7eLA4jQGHTl3gOjhA9+Yd8KSmiLoOPlr6A0kA==",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.3.0.tgz",
+			"integrity": "sha512-sJhgKQl6b4BZOo8jAXpneYFuAkx4wuftGl5KiIDAQZWg+e8YfB41QayjqM2eh0mQkG13hbc4pBOAyR5oFZxK0w==",
 			"dev": true,
 			"requires": {
-				"reakit-utils": "^0.10.0"
+				"reakit-utils": "^0.12.0"
 			}
 		},
 		"realpath-native": {
@@ -18341,9 +18611,9 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.16",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-			"integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+			"version": "0.5.19",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -19114,16 +19384,16 @@
 			}
 		},
 		"stylelint-scss": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.17.0.tgz",
-			"integrity": "sha512-zY6fLHailK3++UEtGOwa5BKeWemLOXUATRlV7H056Z+xCT224/TaLXR5x2zjPXFMEf89uqwv15yM9zhbwm/zDw==",
+			"version": "3.17.1",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.17.1.tgz",
+			"integrity": "sha512-KywqqHfK1otZv1QJA4xJDgcPJp1/cP3jnABpbU9gmXOKqKt8cNt27Imsh9JhY133X8D4zDh/38pNq4WjVfUQWQ==",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.15",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
 				"postcss-selector-parser": "^6.0.2",
-				"postcss-value-parser": "^4.0.2"
+				"postcss-value-parser": "^4.0.3"
 			},
 			"dependencies": {
 				"postcss-selector-parser": {
@@ -19138,9 +19408,9 @@
 					}
 				},
 				"postcss-value-parser": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
-					"integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+					"integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
 					"dev": true
 				}
 			}
@@ -19277,6 +19547,44 @@
 				"yallist": "^3.0.3"
 			}
 		},
+		"tar-fs": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
+			"integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
+			"dev": true,
+			"requires": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.0.0"
+			}
+		},
+		"tar-stream": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
+			"integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+			"dev": true,
+			"requires": {
+				"bl": "^4.0.1",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
@@ -19325,9 +19633,9 @@
 			}
 		},
 		"terser": {
-			"version": "4.6.11",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.11.tgz",
-			"integrity": "sha512-76Ynm7OXUG5xhOpblhytE7X58oeNSmC8xnNhjWVo8CksHit0U0kO4hfNbPrrYwowLWFgM2n9L176VNx2QaHmtA==",
+			"version": "4.6.12",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.12.tgz",
+			"integrity": "sha512-fnIwuaKjFPANG6MAixC/k1TDtnl1YlPLUlLVIxxGZUn1gfUx2+l3/zGNB72wya+lgsb50QBi2tUV75RiODwnww==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.20.0",
@@ -19811,6 +20119,28 @@
 			"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
 			"dev": true
 		},
+		"unbzip2-stream": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.2.tgz",
+			"integrity": "sha512-pZMVAofMrrHX6Ik39hCk470kulCbmZ2SWfQLPmTWqfJV/oUm0gn1CblvHdUu4+54Je6Jq34x8kY6XjTy6dMkOg==",
+			"dev": true,
+			"requires": {
+				"buffer": "^5.2.1",
+				"through": "^2.3.8"
+			},
+			"dependencies": {
+				"buffer": {
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+					"dev": true,
+					"requires": {
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4"
+					}
+				}
+			}
+		},
 		"unherit": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
@@ -20065,9 +20395,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.12.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-					"integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+					"version": "6.12.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+					"integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -20103,9 +20433,9 @@
 					}
 				},
 				"schema-utils": {
-					"version": "2.6.5",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.5.tgz",
-					"integrity": "sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==",
+					"version": "2.6.6",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.6.tgz",
+					"integrity": "sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==",
 					"dev": true,
 					"requires": {
 						"ajv": "^6.12.0",
@@ -20393,16 +20723,16 @@
 			"dev": true
 		},
 		"webpack": {
-			"version": "4.42.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.42.1.tgz",
-			"integrity": "sha512-SGfYMigqEfdGchGhFFJ9KyRpQKnipvEvjc1TwrXEPCM6H5Wywu10ka8o3KGrMzSMxMQKt8aCHUFh5DaQ9UmyRg==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.43.0.tgz",
+			"integrity": "sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==",
 			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.9.0",
 				"@webassemblyjs/helper-module-context": "1.9.0",
 				"@webassemblyjs/wasm-edit": "1.9.0",
 				"@webassemblyjs/wasm-parser": "1.9.0",
-				"acorn": "^6.2.1",
+				"acorn": "^6.4.1",
 				"ajv": "^6.10.2",
 				"ajv-keywords": "^3.4.1",
 				"chrome-trace-event": "^1.0.2",
@@ -20419,7 +20749,7 @@
 				"schema-utils": "^1.0.0",
 				"tapable": "^1.1.3",
 				"terser-webpack-plugin": "^1.4.3",
-				"watchpack": "^1.6.0",
+				"watchpack": "^1.6.1",
 				"webpack-sources": "^1.4.1"
 			},
 			"dependencies": {
@@ -20901,9 +21231,9 @@
 			}
 		},
 		"ws": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-			"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
+			"version": "7.2.5",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.5.tgz",
+			"integrity": "sha512-C34cIU4+DB2vMyAbmEKossWq2ZQDr6QEyuuCzWrM9zfw1sGc0mYiJ0UnG9zzNykt49C2Fi34hvr2vssFQRS6EA==",
 			"dev": true
 		},
 		"x-is-string": {
@@ -20952,12 +21282,12 @@
 			"dev": true
 		},
 		"yaml": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.8.3.tgz",
-			"integrity": "sha512-X/v7VDnK+sxbQ2Imq4Jt2PRUsRsP7UcpSl3Llg6+NRRqWLIvxkMFYtH1FmvwNGYRKKPa+EPA4qDBlI9WVG1UKw==",
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.9.2.tgz",
+			"integrity": "sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.8.7"
+				"@babel/runtime": "^7.9.2"
 			}
 		},
 		"yargs": {
@@ -21101,9 +21431,9 @@
 			}
 		},
 		"yargs-parser": {
-			"version": "18.1.2",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
-			"integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
 			"dev": true,
 			"requires": {
 				"camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
 		"url": "https://github.com/WordPress/gutenberg-examples/issues"
 	},
 	"devDependencies": {
-		"@wordpress/components": "^9.4.1",
-		"@wordpress/scripts": "^8.0.1",
+		"@wordpress/components": "^9.5.0",
+		"@wordpress/scripts": "^9.0.0",
 		"lerna": "^3.20.2"
 	},
 	"scripts": {
@@ -29,6 +29,6 @@
 		"test": "wp-scripts test-unit-js",
 		"env:start": "docker-compose up -d",
 		"env:stop": "docker-compose stop",
-		"packages-update": "wp-scripts packages-update && lerna run packages-update"
+		"packages-update": "wp-scripts packages-update"
 	}
 }


### PR DESCRIPTION
This PR updates `@wordpress/scripts` and other dependencies to the latest version.

The notable change is removed ESLint `--rule '@wordpress/i18n-text-domain: 0'` override that was fixed upstream.