### PR TITLE
Update Basic block.

### DIFF
--- a/01-basic/block.asset.php
+++ b/01-basic/block.asset.php
@@ -1,0 +1,1 @@
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-i18n', 'wp-polyfill'), 'version' => 'a35cc1c098b69994c9c6d6dc1416bb90');

--- a/01-basic/block.json
+++ b/01-basic/block.json
@@ -1,0 +1,9 @@
+{
+    "title": "Example: Basic",
+    "name":"gutenberg-examples/example-01-basic",
+    "category":"layout",
+    "icon": "universal-access-alt",
+    "textDomain": "gutenberg-examples",
+    "example":{},
+    "editorScript": "file:./block.js"
+}

--- a/01-basic/index.php
+++ b/01-basic/index.php
@@ -33,26 +33,18 @@ function gutenberg_examples_01_register_block() {
 		// Gutenberg is not active.
 		return;
 	}
-
-	wp_register_script(
-		'gutenberg-examples-01',
-		plugins_url( 'block.js', __FILE__ ),
-		array( 'wp-blocks', 'wp-i18n', 'wp-element' ),
-		filemtime( plugin_dir_path( __FILE__ ) . 'block.js' )
-	);
-
-	register_block_type( 'gutenberg-examples/example-01-basic', array(
-		'editor_script' => 'gutenberg-examples-01',
-	) );
-
-  if ( function_exists( 'wp_set_script_translations' ) ) {
-    /**
-     * May be extended to wp_set_script_translations( 'my-handle', 'my-domain',
-     * plugin_dir_path( MY_PLUGIN ) . 'languages' ) ). For details see
-     * https://make.wordpress.org/core/2018/11/09/new-javascript-i18n-support-in-wordpress/
-     */
-    wp_set_script_translations( 'gutenberg-examples-01', 'gutenberg-examples' );
-  }
+	
+	// __DIR__ is the current directory where block.json file is stored.
+	register_block_type( __DIR__ );
+	
+	if ( function_exists( 'wp_set_script_translations' ) ) {
+		/**
+		 * May be extended to wp_set_script_translations( 'my-handle', 'my-domain',
+		 * plugin_dir_path( MY_PLUGIN ) . 'languages' ) ). For details see
+		 * https://make.wordpress.org/core/2018/11/09/new-javascript-i18n-support-in-wordpress/
+		 */
+		wp_set_script_translations( 'gutenberg-examples-01', 'gutenberg-examples' );
+	}
 
 }
 add_action( 'init', 'gutenberg_examples_01_register_block' );


### PR DESCRIPTION
This PR updates the `01-basic` block to use a `block.json` file. 

One potential issue I noticed is that because the block doesn't have a build process,  no `*.asset.php` file is generated. This requires that it be added manually in order to have the block successfully registered via `register_block_type` and `block.json`. 

It does beg the question, do we need to have an official approach for creating custom blocks that don't use build processes? 



