### PR TITLE
Remove polyfill dependencies

### DIFF
--- a/01-basic-esnext/build/index.asset.php
+++ b/01-basic-esnext/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-polyfill'), 'version' => 'd03b1c932e40e0ab9ea5054ddeec54c2');
+<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-element', 'wp-i18n' ), 'version' => 'd03b1c932e40e0ab9ea5054ddeec54c2');

--- a/01-basic/block.asset.php
+++ b/01-basic/block.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-i18n', 'wp-polyfill'), 'version' => 'a35cc1c098b69994c9c6d6dc1416bb90');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-i18n' ), 'version' => 'a35cc1c098b69994c9c6d6dc1416bb90');

--- a/03-editable-esnext/build/index.asset.php
+++ b/03-editable-esnext/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-polyfill'), 'version' => 'ebd43150f92e5b16ea18cc759afffddc');
+<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-element', 'wp-i18n' ), 'version' => 'ebd43150f92e5b16ea18cc759afffddc');

--- a/04-controls-esnext/build/index.asset.php
+++ b/04-controls-esnext/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-polyfill'), 'version' => '1308fa13597c9c273fa3727655254927');
+<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-element', 'wp-i18n' ), 'version' => '1308fa13597c9c273fa3727655254927');

--- a/05-recipe-card-esnext/build/index.asset.php
+++ b/05-recipe-card-esnext/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-components', 'wp-element', 'wp-i18n', 'wp-polyfill'), 'version' => '2b0821ce0f4b62aefa95466fb32e752e');
+<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-components', 'wp-element', 'wp-i18n' ), 'version' => '2b0821ce0f4b62aefa95466fb32e752e');

--- a/06-inner-blocks-esnext/build/index.asset.php
+++ b/06-inner-blocks-esnext/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-element', 'wp-polyfill'), 'version' => '3e3feaa0b42d475ad1dba41bcf282508');
+<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-element' ), 'version' => '3e3feaa0b42d475ad1dba41bcf282508');


### PR DESCRIPTION
# Description

With the merging of https://github.com/WordPress/gutenberg/pull/35038
the wp-polyfill is no longer a required dependency for the blocks.


