### PR TITLE
Add the block.json schema to each block.json file

### DIFF
--- a/01-basic-esnext/block.json
+++ b/01-basic-esnext/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/block.json",
 	"apiVersion": 2,
 	"name": "gutenberg-examples/example-01-basic-esnext",
 	"title": "Example: Basic (ESNext)",

--- a/01-basic/block.json
+++ b/01-basic/block.json
@@ -1,9 +1,10 @@
 {
+	"$schema": "https://json.schemastore.org/block.json",
 	"title": "Example: Basic",
 	"name": "gutenberg-examples/example-01-basic",
 	"category": "layout",
 	"icon": "universal-access-alt",
-	"textDomain": "gutenberg-examples",
+	"textdomain": "gutenberg-examples",
 	"example": {},
 	"editorScript": "file:./block.js"
 }

--- a/02-stylesheets/block.json
+++ b/02-stylesheets/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/block.json",
 	"apiVersion": 2,
 	"name": "gutenberg-examples/example-02-stylesheets",
 	"title": "Example: Stylesheets",

--- a/03-editable-esnext/block.json
+++ b/03-editable-esnext/block.json
@@ -8,8 +8,8 @@
 	"category": "layout",
 	"attributes": {
 		"content": {
-			"type": "array",
-			"source": "children",
+			"type": "string",
+			"source": "html",
 			"selector": "p"
 		}
 	},

--- a/03-editable-esnext/block.json
+++ b/03-editable-esnext/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/block.json",
 	"apiVersion": 2,
 	"name": "gutenberg-examples/example-03-editable-esnext",
 	"title": "Example: Editable (ESNext)",

--- a/03-editable/block.json
+++ b/03-editable/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/block.json",
 	"apiVersion": 2,
 	"name": "gutenberg-examples/example-03-editable",
 	"title": "Example: Editable",

--- a/03-editable/block.json
+++ b/03-editable/block.json
@@ -7,8 +7,8 @@
 	"category": "layout",
 	"attributes": {
 		"content": {
-			"type": "array",
-			"source": "children",
+			"type": "string",
+			"source": "html",
 			"selector": "p"
 		}
 	},

--- a/04-controls-esnext/block.json
+++ b/04-controls-esnext/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/block.json",
 	"apiVersion": 2,
 	"name": "gutenberg-examples/example-04-controls-esnext",
 	"title": "Example: Controls (ESNext)",

--- a/04-controls-esnext/block.json
+++ b/04-controls-esnext/block.json
@@ -8,8 +8,8 @@
 	"category": "layout",
 	"attributes": {
 		"content": {
-			"type": "array",
-			"source": "children",
+			"type": "string",
+			"source": "html",
 			"selector": "p"
 		},
 		"alignment": {

--- a/04-controls/block.json
+++ b/04-controls/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/block.json",
 	"apiVersion": 2,
 	"name": "gutenberg-examples/example-04-controls",
 	"title": "Example: Controls",

--- a/04-controls/block.json
+++ b/04-controls/block.json
@@ -7,8 +7,8 @@
 	"category": "layout",
 	"attributes": {
 		"content": {
-			"type": "array",
-			"source": "children",
+			"type": "string",
+			"source": "html",
 			"selector": "p"
 		},
 		"alignment": {

--- a/05-recipe-card-esnext/block.json
+++ b/05-recipe-card-esnext/block.json
@@ -7,8 +7,8 @@
 	"category": "layout",
 	"attributes": {
 		"title": {
-			"type": "array",
-			"source": "children",
+			"type": "string",
+			"source": "html",
 			"selector": "h2"
 		},
 		"mediaID": {
@@ -21,13 +21,13 @@
 			"attribute": "src"
 		},
 		"ingredients": {
-			"type": "array",
-			"source": "children",
+			"type": "string",
+			"source": "html",
 			"selector": ".ingredients"
 		},
 		"instructions": {
-			"type": "array",
-			"source": "children",
+			"type": "string",
+			"source": "html",
 			"selector": ".steps"
 		}
 	},
@@ -37,15 +37,15 @@
 			"mediaID": 1,
 			"mediaURL": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/2ChocolateChipCookies.jpg/320px-2ChocolateChipCookies.jpg",
 			"ingredients": [
-				{ "type": "li", "props": { "children": [ "flour" ] } },
-				{ "type": "li", "props": { "children": [ "sugar" ] } },
-				{ "type": "li", "props": { "children": [ "chocolate" ] } },
-				{ "type": "li", "props": { "children": [ "💖" ] } }
+				{ "type": "li", "props": { "children": ["flour"] } },
+				{ "type": "li", "props": { "children": ["sugar"] } },
+				{ "type": "li", "props": { "children": ["chocolate"] } },
+				{ "type": "li", "props": { "children": ["💖"] } }
 			],
 			"instructions": [
 				{
 					"type": "p",
-					"props": { "children": [ "Mix, Bake, Enjoy!" ] }
+					"props": { "children": ["Mix, Bake, Enjoy!"] }
 				}
 			]
 		}

--- a/05-recipe-card-esnext/block.json
+++ b/05-recipe-card-esnext/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/block.json",
 	"apiVersion": 2,
 	"name": "gutenberg-examples/example-05-recipe-card-esnext",
 	"title": "Example: Recipe Card (ESNext)",

--- a/05-recipe-card/block.json
+++ b/05-recipe-card/block.json
@@ -7,8 +7,8 @@
 	"category": "layout",
 	"attributes": {
 		"title": {
-			"type": "array",
-			"source": "children",
+			"type": "string",
+			"source": "html",
 			"selector": "h2"
 		},
 		"mediaID": {
@@ -21,13 +21,13 @@
 			"attribute": "src"
 		},
 		"ingredients": {
-			"type": "array",
-			"source": "children",
+			"type": "string",
+			"source": "html",
 			"selector": ".ingredients"
 		},
 		"instructions": {
-			"type": "array",
-			"source": "children",
+			"type": "string",
+			"source": "html",
 			"selector": ".steps"
 		}
 	},
@@ -35,8 +35,8 @@
 		"attributes": {
 			"title": "Chocolate Chip Cookies",
 			"mediaURL": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/2ChocolateChipCookies.jpg/320px-2ChocolateChipCookies.jpg",
-			"ingredients": [ "flour", "sugar", "chocolate", "💖" ],
-			"instructions": [ "Mix", "Bake", "Enjoy" ]
+			"ingredients": ["flour", "sugar", "chocolate", "💖"],
+			"instructions": ["Mix", "Bake", "Enjoy"]
 		}
 	},
 	"editorScript": "file:./block.js",

--- a/05-recipe-card/block.json
+++ b/05-recipe-card/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/block.json",
 	"apiVersion": 2,
 	"name": "gutenberg-examples/example-05-recipe-card",
 	"title": "Example: Recipe Card",

--- a/06-inner-blocks-esnext/block.json
+++ b/06-inner-blocks-esnext/block.json
@@ -1,10 +1,11 @@
 {
+	"$schema": "https://json.schemastore.org/block.json",
 	"apiVersion": 2,
 	"name": "gutenberg-examples/example-06-esnext",
 	"title": "Example: Inner Blocks (ESNext)",
 	"category": "layout",
 	"icon": "universal-access-alt",
-	"textDomain": "gutenberg-examples",
+	"textdomain": "gutenberg-examples",
 	"example": {},
 	"editorScript": "file:./build/index.js"
 }

--- a/06-inner-blocks/block.json
+++ b/06-inner-blocks/block.json
@@ -1,10 +1,11 @@
 {
+	"$schema": "https://json.schemastore.org/block.json",
 	"apiVersion": 2,
 	"name": "gutenberg-examples/example-06",
 	"title": "Example: Inner Blocks",
 	"category": "layout",
 	"icon": "universal-access-alt",
-	"textDomain": "gutenberg-examples",
+	"textdomain": "gutenberg-examples",
 	"example": {},
 	"editorScript": "file:./block.js"
 }


### PR DESCRIPTION
Added schema defintion to each file, this allows validation and auto complete in supported browers.

	"$schema": "https://json.schemastore.org/block.json"

Required fixing the textDomain => textdomain

Highlighted an issue with `source: children` still being used when it should be switched to `html`.

See comment here: https://github.com/WordPress/gutenberg/pull/10439#issuecomment-431304068

