### PR TITLE
Fix missing text-domain in 04-controls

### DIFF
--- a/04-controls/block.js
+++ b/04-controls/block.js
@@ -30,7 +30,7 @@
 
 		example: {
 			attributes: {
-				content: __( 'Hello world' ),
+				content: __( 'Hello world', 'gutenberg-examples' ),
 				alignment: 'right',
 			},
 		},


### PR DESCRIPTION
One string in the `04-controls` example is missing a text-domain. Let's add it to give a better example on how to properly localize strings :)