### PR TITLE
Properly prepare 06-inner-blocks example for i18n

### DIFF
--- a/06-inner-blocks/block.js
+++ b/06-inner-blocks/block.js
@@ -1,9 +1,10 @@
-( function( blocks, element, blockEditor ) {
+( function( blocks, i18n, element, blockEditor ) {
+	var __ = i18n.__;
 	var el = element.createElement;
 	var InnerBlocks = blockEditor.InnerBlocks;
 	var useBlockProps = blockEditor.useBlockProps;
 	blocks.registerBlockType( 'gutenberg-examples/example-06', {
-		title: 'Example: Inner Blocks',
+		title: __( 'Example: Inner Blocks', 'gutenberg-examples' ),
 		category: 'layout',
 		edit: function() {
 			return el(


### PR DESCRIPTION
There's one string not properly prepared for internationalization in the `06-inner-blocks` example. This PR fixes the issue :)