### PR TITLE
Fix missing parameter in `inner blocks` example

### DIFF
--- a/06-inner-blocks/block.js
+++ b/06-inner-blocks/block.js
@@ -21,4 +21,4 @@
 			);
 		},
 	} );
-}( window.wp.blocks, window.wp.element, window.wp.blockEditor ) );
+}( window.wp.blocks, window.wp.i18n, window.wp.element, window.wp.blockEditor ) );


### PR DESCRIPTION
By testing this PR: https://github.com/WordPress/gutenberg-examples/pull/188, I found this missing parameter causing an error.