### PR TITLE
Content attribute type array instead of string in blocks-non-jsx/03-editable block example

### DIFF
--- a/blocks-non-jsx/03-editable/block.js
+++ b/blocks-non-jsx/03-editable/block.js
@@ -11,23 +11,6 @@
 	var useBlockProps = blockEditor.useBlockProps;
 
 	blocks.registerBlockType( 'gutenberg-examples/example-03-editable', {
-		title: __( 'Example: Editable', 'gutenberg-examples' ),
-		icon: 'universal-access-alt',
-		category: 'layout',
-
-		attributes: {
-			content: {
-				type: 'array',
-				source: 'children',
-				selector: 'p',
-			},
-		},
-
-		example: {
-			attributes: {
-				content: __( 'Hello world' ),
-			},
-		},
 
 		edit: function ( props ) {
 			var content = props.attributes.content;

--- a/blocks-non-jsx/03-editable/block.json
+++ b/blocks-non-jsx/03-editable/block.json
@@ -5,6 +5,7 @@
 	"title": "Example: Editable",
 	"icon": "universal-access-alt",
 	"category": "layout",
+	"textdomain": "gutenberg-examples",
 	"attributes": {
 		"content": {
 			"type": "string",


### PR DESCRIPTION
I removed all the attributes in the PHP's block registration, since we have all of them in blocks.json already and they seem to be more correct (blocks.json is using a string instead of an array for content attribute type)

Related bug: https://github.com/WordPress/gutenberg-examples/issues/220