### PR TITLE
Add wp-block-editor as dependency for the basic example

### DIFF
--- a/blocks-non-jsx/01-basic/block.asset.php
+++ b/blocks-non-jsx/01-basic/block.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-i18n' ), 'version' => 'a35cc1c098b69994c9c6d6dc1416bb90');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-i18n', 'wp-block-editor' ), 'version' => 'a35cc1c098b69994c9c6d6dc1416bb90');


### PR DESCRIPTION
It didn't work for me until I added this dependency.