### PR TITLE
Fixes block variable name in template.php

### DIFF
--- a/blocks-jsx/10-dynamic-block/template.php
+++ b/blocks-jsx/10-dynamic-block/template.php
@@ -4,7 +4,7 @@
  *
  * @param array    $attributes     The array of attributes for this block.
  * @param string   $content        Rendered block output. ie. <InnerBlocks.Content />.
- * @param WP_Block $block_instance The instance of the WP_Block class that represents the block being rendered.
+ * @param WP_Block $block          The instance of the WP_Block class that represents the block being rendered.
  *
  * @package gutenberg-examples
  */


### PR DESCRIPTION
The Block Instance variable available in the render template of a dynamic block is just `$block` not `$block_instance`. This PR closes #247 

Reference: https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render