### PR TITLE
Custom categories for examples

### DIFF
--- a/blocks-jsx/01-basic-esnext/block.json
+++ b/blocks-jsx/01-basic-esnext/block.json
@@ -5,7 +5,7 @@
 	"title": "Example: Basic (ESNext)",
 	"textdomain": "gutenberg-examples",
 	"icon": "universal-access-alt",
-	"category": "layout",
+	"category": "jsx-examples",
 	"example": {},
 	"editorScript": "file:./index.js"
 }

--- a/blocks-jsx/03-editable-esnext/block.json
+++ b/blocks-jsx/03-editable-esnext/block.json
@@ -5,7 +5,7 @@
 	"title": "Example: Editable (ESNext)",
 	"textdomain": "gutenberg-examples",
 	"icon": "universal-access-alt",
-	"category": "layout",
+	"category": "jsx-examples",
 	"attributes": {
 		"content": {
 			"type": "string",

--- a/blocks-jsx/04-controls-esnext/block.json
+++ b/blocks-jsx/04-controls-esnext/block.json
@@ -5,7 +5,7 @@
 	"title": "Example: Controls (ESNext)",
 	"textdomain": "gutenberg-examples",
 	"icon": "universal-access-alt",
-	"category": "layout",
+	"category": "jsx-examples",
 	"attributes": {
 		"content": {
 			"type": "string",

--- a/blocks-jsx/05-recipe-card-esnext/block.json
+++ b/blocks-jsx/05-recipe-card-esnext/block.json
@@ -4,7 +4,7 @@
 	"name": "gutenberg-examples/example-05-recipe-card-esnext",
 	"title": "Example: Recipe Card (ESNext)",
 	"icon": "index-card",
-	"category": "layout",
+	"category": "jsx-examples",
 	"attributes": {
 		"title": {
 			"type": "string",

--- a/blocks-jsx/06-inner-blocks-esnext/block.json
+++ b/blocks-jsx/06-inner-blocks-esnext/block.json
@@ -3,7 +3,7 @@
 	"apiVersion": 2,
 	"name": "gutenberg-examples/example-06-esnext",
 	"title": "Example: Inner Blocks (ESNext)",
-	"category": "layout",
+	"category": "jsx-examples",
 	"icon": "universal-access-alt",
 	"textdomain": "gutenberg-examples",
 	"example": {},

--- a/blocks-jsx/08-block-supports-esnext/block.json
+++ b/blocks-jsx/08-block-supports-esnext/block.json
@@ -5,7 +5,7 @@
 	"title": "Example: Block Supports (ESNext)",
 	"textdomain": "gutenberg-examples",
 	"icon": "universal-access-alt",
-	"category": "layout",
+	"category": "jsx-examples",
 	"attributes": {
 		"content": {
 			"type": "string",

--- a/blocks-jsx/10-dynamic-block/block.json
+++ b/blocks-jsx/10-dynamic-block/block.json
@@ -4,7 +4,7 @@
 	"name": "gutenberg-examples/dynamic-block",
 	"version": "0.1.0",
 	"title": "Example: Dynamic Block (ESNext)",
-	"category": "text",
+	"category": "jsx-examples",
 	"icon": "universal-access-alt",
 	"attributes": {
 		"message": {

--- a/blocks-jsx/meta-block/block.json
+++ b/blocks-jsx/meta-block/block.json
@@ -4,7 +4,7 @@
 	"name": "myguten/meta-block",
 	"version": "0.1.0",
 	"title": "meta-block",
-	"category": "text",
+	"category": "jsx-examples",
 	"icon": "smiley",
 	"description": "An example block viewing and saving post meta",
 	"supports": {

--- a/blocks-non-jsx/01-basic/block.json
+++ b/blocks-non-jsx/01-basic/block.json
@@ -3,7 +3,7 @@
 	"apiVersion": 2,
 	"title": "Example: Basic",
 	"name": "gutenberg-examples/example-01-basic",
-	"category": "layout",
+	"category": "non-jsx-examples",
 	"icon": "universal-access-alt",
 	"textdomain": "gutenberg-examples",
 	"example": {},

--- a/blocks-non-jsx/02-stylesheets/block.js
+++ b/blocks-non-jsx/02-stylesheets/block.js
@@ -16,7 +16,7 @@
 	blocks.registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
 		title: __( 'Example: Stylesheets', 'gutenberg-examples' ),
 		icon: 'universal-access-alt',
-		category: 'layout',
+		"category": 'non-jsx-examples',
 		example: {},
 		edit: function ( props ) {
 			return el(

--- a/blocks-non-jsx/03-editable/block.json
+++ b/blocks-non-jsx/03-editable/block.json
@@ -4,7 +4,7 @@
 	"name": "gutenberg-examples/example-03-editable",
 	"title": "Example: Editable",
 	"icon": "universal-access-alt",
-	"category": "layout",
+	"category": "non-jsx-examples",
 	"textdomain": "gutenberg-examples",
 	"attributes": {
 		"content": {

--- a/blocks-non-jsx/04-controls/block.js
+++ b/blocks-non-jsx/04-controls/block.js
@@ -14,7 +14,7 @@
 	blocks.registerBlockType( 'gutenberg-examples/example-04-controls', {
 		title: __( 'Example: Controls', 'gutenberg-examples' ),
 		icon: 'universal-access-alt',
-		category: 'layout',
+		"category": 'non-jsx-examples',
 
 		attributes: {
 			content: {

--- a/blocks-non-jsx/05-recipe-card/block.js
+++ b/blocks-non-jsx/05-recipe-card/block.js
@@ -8,7 +8,7 @@
 	blocks.registerBlockType( 'gutenberg-examples/example-05-recipe-card', {
 		title: __( 'Example: Recipe Card', 'gutenberg-examples' ),
 		icon: 'index-card',
-		category: 'layout',
+		"category": 'non-jsx-examples',
 		attributes: {
 			title: {
 				type: 'array',

--- a/blocks-non-jsx/06-inner-blocks/block.js
+++ b/blocks-non-jsx/06-inner-blocks/block.js
@@ -5,7 +5,7 @@
 	var useBlockProps = blockEditor.useBlockProps;
 	blocks.registerBlockType( 'gutenberg-examples/example-06', {
 		title: __( 'Example: Inner Blocks', 'gutenberg-examples' ),
-		category: 'layout',
+		"category": 'non-jsx-examples',
 		edit: function () {
 			return el( 'div', useBlockProps(), el( InnerBlocks ) );
 		},

--- a/index.php
+++ b/index.php
@@ -11,6 +11,22 @@
 
 defined( 'ABSPATH' ) || exit;
 
+function gutenberg_examples_block_categories( $categories ) {
+    return array_merge(
+        $categories,
+        [
+            [
+                'slug'  => 'jsx-examples',
+                'title' => 'Examples - JSX'
+            ],
+            [
+                'slug'  => 'non-jsx-examples',
+                'title' => 'Examples - Non JSX'
+            ],
+        ]
+    );
+}
+add_action( 'block_categories', 'gutenberg_examples_block_categories', 10, 2 );
 
 require plugin_dir_path( __FILE__ ) . 'blocks-non-jsx/01-basic/index.php';
 require plugin_dir_path( __FILE__ ) . 'build/blocks-jsx/01-basic-esnext/index.php';


### PR DESCRIPTION
This PR groups each type of block in its own custom category in the inserter to simplify finding the block you're interested in in the Block Editor.

<img width="329" alt="Screenshot 2023-08-27 at 18 42 08" src="https://github.com/WordPress/gutenberg-examples/assets/422576/e5b37f05-e401-4b1a-8c2a-a2a1e941f3c1">
